### PR TITLE
Add pipeline detail page with sync state and stream data

### DIFF
--- a/src/components/pipeline/pipeline-header.tsx
+++ b/src/components/pipeline/pipeline-header.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { StatusBadge } from "@/components/dashboard/status-badge";
+import { formatDistanceToNow } from "date-fns";
+import type { PipelineDetailResponse } from "@/lib/types/api";
+
+interface PipelineHeaderProps {
+  pipeline: PipelineDetailResponse;
+}
+
+export function PipelineHeader({ pipeline }: PipelineHeaderProps) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <h1 className="text-2xl font-bold tracking-tight">
+          {pipeline.clientName}
+          <span className="text-muted-foreground font-normal"> / </span>
+          {pipeline.connectorType}
+        </h1>
+        <StatusBadge status={pipeline.status} />
+        {!pipeline.enabled && (
+          <Badge variant="outline" className="text-muted-foreground">
+            Disabled
+          </Badge>
+        )}
+      </div>
+
+      <div className="text-muted-foreground flex flex-wrap gap-x-6 gap-y-1 text-sm">
+        <span>
+          <span className="font-medium text-foreground">Schedule:</span>{" "}
+          {pipeline.scheduleExpression}
+        </span>
+        <span>
+          <span className="font-medium text-foreground">Destination:</span>{" "}
+          {pipeline.destinationType}
+        </span>
+        <span>
+          <span className="font-medium text-foreground">Environment:</span>{" "}
+          {pipeline.environment}
+        </span>
+        {pipeline.lastSync && (
+          <span>
+            <span className="font-medium text-foreground">Last sync:</span>{" "}
+            {formatDistanceToNow(new Date(pipeline.lastSync.timestamp), {
+              addSuffix: true,
+            })}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/pipeline/recent-executions.tsx
+++ b/src/components/pipeline/recent-executions.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import Link from "next/link";
+import { CheckCircle2, XCircle, Loader2 } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatDistanceToNow } from "date-fns";
+import type { ExecutionSummaryResponse } from "@/lib/types/api";
+
+interface RecentExecutionsProps {
+  executions: ExecutionSummaryResponse[];
+  pipelineId: string;
+}
+
+function StatusIcon({ status }: { status: string }) {
+  switch (status) {
+    case "SUCCEEDED":
+      return <CheckCircle2 className="size-4 text-emerald-500" />;
+    case "FAILED":
+    case "TIMED_OUT":
+    case "ABORTED":
+      return <XCircle className="size-4 text-red-500" />;
+    case "RUNNING":
+      return <Loader2 className="size-4 animate-spin text-blue-500" />;
+    default:
+      return <div className="size-4 rounded-full bg-zinc-300" />;
+  }
+}
+
+function formatDuration(start: string, stop: string | null): string {
+  if (!stop) return "Running...";
+  const ms = new Date(stop).getTime() - new Date(start).getTime();
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return secs > 0 ? `${mins}m ${secs}s` : `${mins}m`;
+}
+
+// Extract execution ID from ARN (last segment after the last colon)
+function executionIdFromArn(arn: string): string {
+  const parts = arn.split(":");
+  return parts[parts.length - 1];
+}
+
+export function RecentExecutions({
+  executions,
+  pipelineId,
+}: RecentExecutionsProps) {
+  if (executions.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent Executions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-sm">
+            No executions found
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Recent Executions</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-10">Status</TableHead>
+              <TableHead>Started</TableHead>
+              <TableHead>Duration</TableHead>
+              <TableHead className="text-right">Details</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {executions.map((exec) => {
+              const executionId = executionIdFromArn(exec.executionArn);
+              return (
+                <TableRow key={exec.executionArn}>
+                  <TableCell>
+                    <StatusIcon status={exec.status} />
+                  </TableCell>
+                  <TableCell>
+                    {formatDistanceToNow(new Date(exec.startDate), {
+                      addSuffix: true,
+                    })}
+                  </TableCell>
+                  <TableCell>
+                    {formatDuration(exec.startDate, exec.stopDate)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Link
+                      href={`/pipelines/${encodeURIComponent(pipelineId)}/executions/${encodeURIComponent(executionId)}`}
+                      className="text-sm text-blue-600 hover:underline"
+                    >
+                      View
+                    </Link>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/pipeline/stream-table.tsx
+++ b/src/components/pipeline/stream-table.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { StreamSummary } from "@/lib/types/api";
+
+interface StreamTableProps {
+  streams: StreamSummary[];
+}
+
+export function StreamTable({ streams }: StreamTableProps) {
+  if (streams.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Streams</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-sm">
+            No stream data available
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Streams</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Stream Name</TableHead>
+              <TableHead className="text-right">Records</TableHead>
+              <TableHead>Cursor Field</TableHead>
+              <TableHead>Cursor Value</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {streams.map((stream) => (
+              <TableRow key={stream.name}>
+                <TableCell className="font-medium">{stream.name}</TableCell>
+                <TableCell className="text-right">
+                  {stream.recordCount?.toLocaleString() ?? "--"}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {stream.cursorField ?? "--"}
+                </TableCell>
+                <TableCell className="font-mono text-xs text-muted-foreground">
+                  {stream.cursorValue ?? "--"}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/pipeline/sync-state-panel.tsx
+++ b/src/components/pipeline/sync-state-panel.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { formatDistanceToNow } from "date-fns";
+import type { SyncStateResponse } from "@/lib/types/api";
+
+interface SyncStatePanelProps {
+  syncState: SyncStateResponse | null;
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return secs > 0 ? `${mins}m ${secs}s` : `${mins}m`;
+}
+
+export function SyncStatePanel({ syncState }: SyncStatePanelProps) {
+  if (!syncState) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Sync State</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-sm">No sync data available</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const statusColor =
+    syncState.lastExecutionStatus === "SUCCESS"
+      ? "bg-emerald-100 text-emerald-700"
+      : syncState.lastExecutionStatus === "FAILED"
+        ? "bg-red-100 text-red-700"
+        : "bg-zinc-100 text-zinc-600";
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Sync State</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <div>
+            <p className="text-muted-foreground text-xs font-medium">
+              Last Sync
+            </p>
+            <p className="text-sm font-medium">
+              {formatDistanceToNow(new Date(syncState.lastSyncTimestamp), {
+                addSuffix: true,
+              })}
+            </p>
+          </div>
+          <div>
+            <p className="text-muted-foreground text-xs font-medium">Status</p>
+            <Badge className={statusColor}>
+              {syncState.lastExecutionStatus}
+            </Badge>
+          </div>
+          <div>
+            <p className="text-muted-foreground text-xs font-medium">
+              Total Records
+            </p>
+            <p className="text-sm font-medium">
+              {syncState.totalRecords?.toLocaleString() ?? "--"}
+            </p>
+          </div>
+          <div>
+            <p className="text-muted-foreground text-xs font-medium">
+              Duration
+            </p>
+            <p className="text-sm font-medium">
+              {syncState.executionDuration != null
+                ? formatDuration(syncState.executionDuration)
+                : "--"}
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/use-pipeline.ts
+++ b/src/hooks/use-pipeline.ts
@@ -1,0 +1,20 @@
+import useSWR from "swr";
+import type { PipelineDetailResponse } from "@/lib/types/api";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export function usePipeline(pipelineId: string) {
+  const { data, error, isLoading, mutate } =
+    useSWR<PipelineDetailResponse>(
+      `/api/pipelines/${encodeURIComponent(pipelineId)}`,
+      fetcher,
+      { refreshInterval: 15_000 }
+    );
+
+  return {
+    pipeline: data,
+    isLoading,
+    error,
+    mutate,
+  };
+}

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -1,5 +1,3 @@
-import type { SyncConfig } from "./pipeline";
-
 // ── Common ──
 
 export type PipelineStatus = "healthy" | "failing" | "running" | "unknown";
@@ -45,11 +43,21 @@ export interface ExecutionSummaryResponse {
   stopDate: string | null;
 }
 
+export interface StreamSummary {
+  name: string;
+  recordCount: number | null;
+  s3Path: string | null;
+  cursorField: string | null;
+  cursorValue: string | null;
+}
+
 export interface SyncStateResponse {
   clientConnector: string;
   lastSyncTimestamp: string;
   lastExecutionStatus: string;
-  syncConfig: SyncConfig;
+  totalRecords: number | null;
+  executionDuration: number | null;
+  streams: StreamSummary[];
 }
 
 export interface MetricDataPointResponse {

--- a/src/lib/types/pipeline.ts
+++ b/src/lib/types/pipeline.ts
@@ -23,15 +23,39 @@ export interface Pipeline {
 
 // ── Sync State (per-pipeline DynamoDB tables) ──
 
-export interface SyncConfig {
-  [key: string]: unknown;
+export interface SyncStreamResult {
+  count: number;
+  s3_path: string;
+}
+
+export interface SyncStats {
+  total_records: number;
+  execution_duration?: number;
+  streams?: string[];
+  partial_completion?: boolean;
+  results?: Record<string, SyncStreamResult>;
+  // HubSpot-style checkpoints
+  is_checkpoint?: boolean;
+  checkpoint_time?: string;
+  streams_with_state?: string[];
+}
+
+export interface AirbyteStreamState {
+  type: string;
+  stream: {
+    stream_descriptor: { name: string };
+    stream_state: Record<string, unknown>;
+  };
+  sourceStats?: { recordCount: number };
 }
 
 export interface SyncState {
   client_connector: string;
-  last_sync_timestamp: string;
+  last_sync: string;
   last_execution_status: string;
-  sync_config: SyncConfig;
+  updated_at?: string;
+  sync_stats?: SyncStats;
+  airbyte_state?: AirbyteStreamState[];
 }
 
 // ── Step Functions ──


### PR DESCRIPTION
## Summary
- Fix backend `SyncState` types to match actual DynamoDB shape (`sync_stats` + `airbyte_state` instead of generic `sync_config`)
- Add `StreamSummary` API type merging sync stats with Airbyte cursor info per stream
- Build `/pipelines/[pipelineId]` detail page with pipeline header, sync state panel, stream table, and recent executions timeline

## Test plan
- [ ] `npm run build` passes with no type errors
- [ ] `npm run lint` passes with no new warnings
- [ ] Navigate from dashboard card to detail page and verify all sections render
- [ ] Verify stream table shows record counts and cursor fields from live data
- [ ] Verify recent executions show status icons, timestamps, and durations
- [ ] Verify 15-second SWR polling refreshes data on the detail page
- [ ] Verify graceful handling when sync state is null (placeholder shown)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)