### PR TITLE
Support OBLIK_AWS_ env var prefix for Amplify

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,7 +1,11 @@
 # AWS Credentials (from Terraform IAM user output)
+# On Amplify, use the OBLIK_AWS_ prefix (Amplify reserves AWS_ prefix)
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_REGION=us-west-1
+# OBLIK_AWS_ACCESS_KEY_ID=
+# OBLIK_AWS_SECRET_ACCESS_KEY=
+# OBLIK_AWS_REGION=us-west-1
 
 # NextAuth
 NEXTAUTH_URL=http://localhost:3000

--- a/src/lib/aws/client.ts
+++ b/src/lib/aws/client.ts
@@ -5,10 +5,10 @@ import { CloudWatchClient } from "@aws-sdk/client-cloudwatch";
 import { CloudWatchLogsClient } from "@aws-sdk/client-cloudwatch-logs";
 
 const awsConfig = {
-  region: process.env.AWS_REGION,
+  region: process.env.OBLIK_AWS_REGION || process.env.AWS_REGION,
   credentials: {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+    accessKeyId: (process.env.OBLIK_AWS_ACCESS_KEY_ID || process.env.AWS_ACCESS_KEY_ID)!,
+    secretAccessKey: (process.env.OBLIK_AWS_SECRET_ACCESS_KEY || process.env.AWS_SECRET_ACCESS_KEY)!,
   },
 };
 


### PR DESCRIPTION
## Summary
- Fall back to `OBLIK_AWS_*` env vars in `src/lib/aws/client.ts` since Amplify reserves the `AWS_` prefix
- Document the `OBLIK_AWS_*` variants in `.env.local.example`

## Test plan
- [ ] `npm run build` passes
- [ ] Local dev still works with `AWS_*` vars in `.env.local`
- [ ] Amplify deploy picks up `OBLIK_AWS_*` vars and connects to AWS services

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)