### PR TITLE
Add basic metrics charts (#11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,10 @@ See `.env.local.example` for all required variables. Key ones:
 - When starting work on a new GitHub issue, always create a feature branch first (e.g., `feat/issue-12-pipeline-detail`) and open a PR against `main` when done.
 - Do not commit directly to `main` for issue work.
 
+## Frontend Design
+
+- Always use the `/frontend-design` skill when building or modifying UI components and pages. This ensures consistent, high-quality design across the dashboard.
+
 ## Architecture Notes
 
 - **Pipeline registry** lives in a DynamoDB table (`oblik-pipeline-registry`)

--- a/src/app/api/pipelines/[pipelineId]/metrics/route.ts
+++ b/src/app/api/pipelines/[pipelineId]/metrics/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import { getPipeline } from "@/lib/aws/dynamodb";
+import { getMetrics } from "@/lib/aws/cloudwatch";
+import {
+  requireAuth,
+  getClientFilter,
+  handleAwsError,
+} from "@/lib/api/helpers";
+import type { MetricPeriod, MetricDataPoint } from "@/lib/types/pipeline";
+import type { PipelineMetricsResponse, MetricDataPointResponse } from "@/lib/types/api";
+
+const VALID_PERIODS = new Set<MetricPeriod>(["7d", "30d"]);
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ pipelineId: string }> }
+) {
+  try {
+    // 1. Authenticate
+    const authResult = await requireAuth();
+    if (authResult.errorResponse) return authResult.errorResponse;
+    const { session } = authResult;
+
+    // 2. Decode pipeline ID
+    const { pipelineId: rawId } = await params;
+    const pipelineId = decodeURIComponent(rawId);
+
+    // 3. Fetch pipeline from registry
+    const pipeline = await getPipeline(pipelineId);
+    if (!pipeline) {
+      return NextResponse.json(
+        { error: "Not Found", message: "Pipeline not found" },
+        { status: 404 }
+      );
+    }
+
+    // 4. Multi-tenant check
+    const allowedClients = getClientFilter(session.user.groups);
+    if (allowedClients && !allowedClients.includes(pipeline.client_name)) {
+      return NextResponse.json(
+        { error: "Not Found", message: "Pipeline not found" },
+        { status: 404 }
+      );
+    }
+
+    // 5. Parse query params
+    const url = new URL(request.url);
+    const periodParam = url.searchParams.get("period") as MetricPeriod | null;
+    const period: MetricPeriod =
+      periodParam && VALID_PERIODS.has(periodParam) ? periodParam : "7d";
+
+    // 6. Fetch metrics
+    const metrics = await getMetrics(pipeline.state_machine_arn, period);
+
+    // 7. Build response
+    const body: PipelineMetricsResponse = {
+      executionsSucceeded: serializeDataPoints(metrics.executionsSucceeded),
+      executionsFailed: serializeDataPoints(metrics.executionsFailed),
+      executionsStarted: serializeDataPoints(metrics.executionsStarted),
+      executionTime: serializeDataPoints(metrics.executionTime),
+    };
+
+    return NextResponse.json(body, {
+      headers: {
+        "Cache-Control": "s-maxage=60, stale-while-revalidate=120",
+      },
+    });
+  } catch (error) {
+    return handleAwsError(error);
+  }
+}
+
+function serializeDataPoints(
+  points: MetricDataPoint[]
+): MetricDataPointResponse[] {
+  return points.map((p) => ({
+    timestamp: p.timestamp.toISOString(),
+    value: p.value,
+  }));
+}

--- a/src/app/pipelines/[pipelineId]/metrics/page.tsx
+++ b/src/app/pipelines/[pipelineId]/metrics/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { AlertCircle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useMetrics, type MetricsPagePeriod } from "@/hooks/use-metrics";
+import { SuccessRateChart } from "@/components/metrics/SuccessRateChart";
+import { DurationChart } from "@/components/metrics/DurationChart";
+
+const PERIODS: { value: MetricsPagePeriod; label: string }[] = [
+  { value: "7d", label: "7 days" },
+  { value: "30d", label: "30 days" },
+];
+
+function MetricsSkeleton() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-80 w-full rounded-xl" />
+      <Skeleton className="h-80 w-full rounded-xl" />
+    </div>
+  );
+}
+
+export default function MetricsPage() {
+  const params = useParams<{ pipelineId: string }>();
+  const pipelineId = decodeURIComponent(params.pipelineId);
+
+  const [period, setPeriod] = useState<MetricsPagePeriod>("7d");
+  const { data, isLoading, error, mutate } = useMetrics(pipelineId, period);
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Metrics</h1>
+          <p className="text-muted-foreground text-sm">{pipelineId}</p>
+        </div>
+        <Link
+          href={`/pipelines/${encodeURIComponent(pipelineId)}`}
+          className="text-sm text-blue-600 hover:underline"
+        >
+          Back to pipeline
+        </Link>
+      </div>
+
+      <div className="flex items-center gap-1">
+        {PERIODS.map((p) => (
+          <Button
+            key={p.value}
+            variant={period === p.value ? "default" : "outline"}
+            size="sm"
+            onClick={() => setPeriod(p.value)}
+          >
+            {p.label}
+          </Button>
+        ))}
+      </div>
+
+      {error ? (
+        <div className="flex flex-col items-center gap-4 rounded-lg border border-red-200 bg-red-50 p-8 text-center">
+          <AlertCircle className="size-8 text-red-500" />
+          <div>
+            <p className="font-medium text-red-800">Failed to load metrics</p>
+            <p className="text-sm text-red-600">
+              {error.message || "An unexpected error occurred."}
+            </p>
+          </div>
+          <Button variant="outline" size="sm" onClick={() => mutate()}>
+            <RefreshCw className="size-4" />
+            Retry
+          </Button>
+        </div>
+      ) : isLoading ? (
+        <MetricsSkeleton />
+      ) : data ? (
+        <div className="space-y-6">
+          <SuccessRateChart
+            succeeded={data.executionsSucceeded}
+            failed={data.executionsFailed}
+          />
+          <DurationChart executionTime={data.executionTime} />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/pipelines/[pipelineId]/page.tsx
+++ b/src/app/pipelines/[pipelineId]/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useParams } from "next/navigation";
-import { AlertCircle, RefreshCw } from "lucide-react";
+import Link from "next/link";
+import { AlertCircle, RefreshCw, BarChart3 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { usePipeline } from "@/hooks/use-pipeline";
@@ -67,6 +68,13 @@ export default function PipelineDetailPage() {
             executions={pipeline.recentExecutions}
             pipelineId={pipeline.pipelineId}
           />
+          <Link
+            href={`/pipelines/${encodeURIComponent(pipeline.pipelineId)}/metrics`}
+            className="inline-flex items-center gap-2 text-sm text-blue-600 hover:underline"
+          >
+            <BarChart3 className="size-4" />
+            View Metrics
+          </Link>
         </>
       )}
     </div>

--- a/src/components/layout/breadcrumb-nav.tsx
+++ b/src/components/layout/breadcrumb-nav.tsx
@@ -94,6 +94,38 @@ export function BreadcrumbNav() {
     );
   }
 
+  // /pipelines/[id]/metrics → Pipelines > id > Metrics
+  const metricsMatch = pathname.match(
+    /^\/pipelines\/([^/]+)\/metrics$/
+  );
+
+  if (metricsMatch) {
+    const pipelineId = decodeURIComponent(metricsMatch[1]);
+    return (
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href="/">Pipelines</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href={`/pipelines/${encodeURIComponent(pipelineId)}`}>
+                {pipelineId}
+              </Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Metrics</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+    );
+  }
+
   // /pipelines/[id] → ["Pipelines", decoded id]
   const pipelineMatch = pathname.match(/^\/pipelines\/([^/]+)/)
 

--- a/src/components/metrics/DurationChart.tsx
+++ b/src/components/metrics/DurationChart.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useMemo } from "react";
+import { format, parseISO } from "date-fns";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import type { MetricDataPointResponse } from "@/lib/types/api";
+
+interface DurationChartProps {
+  executionTime: MetricDataPointResponse[];
+}
+
+interface DurationDataPoint {
+  timestamp: string;
+  dateLabel: string;
+  durationMs: number;
+  durationLabel: string;
+}
+
+function formatDurationMs(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const minutes = seconds / 60;
+  if (minutes < 60) return `${minutes.toFixed(1)}m`;
+  const hours = minutes / 60;
+  return `${hours.toFixed(1)}h`;
+}
+
+function formatYAxisDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  const minutes = seconds / 60;
+  if (minutes < 60) return `${Math.round(minutes)}m`;
+  const hours = minutes / 60;
+  return `${hours.toFixed(1)}h`;
+}
+
+export function DurationChart({ executionTime }: DurationChartProps) {
+  const data = useMemo(() => {
+    return executionTime
+      .map((point): DurationDataPoint => ({
+        timestamp: point.timestamp,
+        dateLabel: format(parseISO(point.timestamp), "MMM d"),
+        durationMs: point.value,
+        durationLabel: formatDurationMs(point.value),
+      }))
+      .sort(
+        (a, b) =>
+          new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+      );
+  }, [executionTime]);
+
+  const isEmpty = data.length === 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Execution Duration</CardTitle>
+        <CardDescription>
+          Average execution time per period
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isEmpty ? (
+          <div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
+            No duration data available for this period
+          </div>
+        ) : (
+          <div className="h-72">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart
+                data={data}
+                margin={{ top: 4, right: 12, bottom: 4, left: -8 }}
+              >
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  vertical={false}
+                  stroke="var(--color-border)"
+                />
+                <XAxis
+                  dataKey="dateLabel"
+                  tick={{ fontSize: 12, fill: "var(--color-muted-foreground)" }}
+                  tickLine={false}
+                  axisLine={false}
+                  dy={8}
+                />
+                <YAxis
+                  tickFormatter={formatYAxisDuration}
+                  tick={{ fontSize: 12, fill: "var(--color-muted-foreground)" }}
+                  tickLine={false}
+                  axisLine={false}
+                  dx={-4}
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: "var(--color-popover)",
+                    borderColor: "var(--color-border)",
+                    borderRadius: "var(--radius-md)",
+                    color: "var(--color-popover-foreground)",
+                    fontSize: 13,
+                  }}
+                  labelFormatter={(_, payload) => {
+                    if (payload?.[0]?.payload?.timestamp) {
+                      return format(
+                        parseISO(payload[0].payload.timestamp),
+                        "MMM d, h:mm a"
+                      );
+                    }
+                    return "";
+                  }}
+                  formatter={(value?: number | string) => [
+                    formatDurationMs(Number(value ?? 0)),
+                    "Avg Duration",
+                  ]}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="durationMs"
+                  name="Avg Duration"
+                  stroke="#3b82f6"
+                  strokeWidth={2}
+                  dot={false}
+                  activeDot={{ r: 4, strokeWidth: 0 }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/metrics/SuccessRateChart.tsx
+++ b/src/components/metrics/SuccessRateChart.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useMemo } from "react";
+import { format, parseISO } from "date-fns";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import type { MetricDataPointResponse } from "@/lib/types/api";
+
+interface SuccessRateChartProps {
+  succeeded: MetricDataPointResponse[];
+  failed: MetricDataPointResponse[];
+}
+
+interface MergedDataPoint {
+  timestamp: string;
+  dateLabel: string;
+  succeeded: number;
+  failed: number;
+}
+
+export function SuccessRateChart({
+  succeeded,
+  failed,
+}: SuccessRateChartProps) {
+  const data = useMemo(() => {
+    const map = new Map<string, MergedDataPoint>();
+
+    for (const point of succeeded) {
+      const key = point.timestamp;
+      const existing = map.get(key);
+      if (existing) {
+        existing.succeeded = point.value;
+      } else {
+        map.set(key, {
+          timestamp: key,
+          dateLabel: format(parseISO(key), "MMM d"),
+          succeeded: point.value,
+          failed: 0,
+        });
+      }
+    }
+
+    for (const point of failed) {
+      const key = point.timestamp;
+      const existing = map.get(key);
+      if (existing) {
+        existing.failed = point.value;
+      } else {
+        map.set(key, {
+          timestamp: key,
+          dateLabel: format(parseISO(key), "MMM d"),
+          succeeded: 0,
+          failed: point.value,
+        });
+      }
+    }
+
+    return Array.from(map.values()).sort(
+      (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    );
+  }, [succeeded, failed]);
+
+  const isEmpty = data.length === 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Execution Results</CardTitle>
+        <CardDescription>
+          Succeeded and failed execution counts over time
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isEmpty ? (
+          <div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
+            No execution data available for this period
+          </div>
+        ) : (
+          <div className="h-72">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart
+                data={data}
+                margin={{ top: 4, right: 12, bottom: 4, left: -8 }}
+              >
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  vertical={false}
+                  stroke="var(--color-border)"
+                />
+                <XAxis
+                  dataKey="dateLabel"
+                  tick={{ fontSize: 12, fill: "var(--color-muted-foreground)" }}
+                  tickLine={false}
+                  axisLine={false}
+                  dy={8}
+                />
+                <YAxis
+                  allowDecimals={false}
+                  tick={{ fontSize: 12, fill: "var(--color-muted-foreground)" }}
+                  tickLine={false}
+                  axisLine={false}
+                  dx={-4}
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: "var(--color-popover)",
+                    borderColor: "var(--color-border)",
+                    borderRadius: "var(--radius-md)",
+                    color: "var(--color-popover-foreground)",
+                    fontSize: 13,
+                  }}
+                  labelFormatter={(_, payload) => {
+                    if (payload?.[0]?.payload?.timestamp) {
+                      return format(
+                        parseISO(payload[0].payload.timestamp),
+                        "MMM d, h:mm a"
+                      );
+                    }
+                    return "";
+                  }}
+                />
+                <Legend
+                  verticalAlign="top"
+                  align="right"
+                  iconType="circle"
+                  iconSize={8}
+                  wrapperStyle={{ fontSize: 12, paddingBottom: 8 }}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="succeeded"
+                  name="Succeeded"
+                  stroke="#22c55e"
+                  strokeWidth={2}
+                  dot={false}
+                  activeDot={{ r: 4, strokeWidth: 0 }}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="failed"
+                  name="Failed"
+                  stroke="#ef4444"
+                  strokeWidth={2}
+                  dot={false}
+                  activeDot={{ r: 4, strokeWidth: 0 }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/use-metrics.ts
+++ b/src/hooks/use-metrics.ts
@@ -1,0 +1,22 @@
+import useSWR from "swr";
+import type { PipelineMetricsResponse } from "@/lib/types/api";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export type MetricsPagePeriod = "7d" | "30d";
+
+export function useMetrics(pipelineId: string, period: MetricsPagePeriod) {
+  const url = `/api/pipelines/${encodeURIComponent(pipelineId)}/metrics?period=${period}`;
+
+  const { data, error, isLoading, mutate } =
+    useSWR<PipelineMetricsResponse>(url, fetcher, {
+      refreshInterval: 60_000,
+    });
+
+  return {
+    data,
+    isLoading,
+    error,
+    mutate,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a dedicated `/pipelines/[id]/metrics` page with time-series line charts for execution success/failure counts and average duration
- Includes a metrics API route (`/api/pipelines/[id]/metrics?period=7d|30d`) with auth and multi-tenant filtering
- Period switcher (7d / 30d) toggles chart granularity (hourly vs 6-hour buckets)
- Adds "View Metrics" link on pipeline detail page and breadcrumb navigation for the metrics page

## Test plan
- [ ] Navigate to `/pipelines/{id}/metrics` and verify both charts render with CloudWatch data
- [ ] Toggle between 7d and 30d periods — charts should refetch and re-render
- [ ] Verify empty states display correctly when no metric data exists
- [ ] Confirm breadcrumb shows Pipelines > {id} > Metrics
- [ ] Confirm "View Metrics" link appears on pipeline detail page and navigates correctly
- [ ] Verify `npm run build` passes with no type errors

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)