### PR TITLE
Add auto-refresh indicators and stale data warning (#12)

### DIFF
--- a/src/hooks/use-execution-detail.ts
+++ b/src/hooks/use-execution-detail.ts
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import useSWR from "swr";
 import type { ExecutionDetailResponse } from "@/lib/types/api";
 
@@ -5,11 +6,16 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
 export function useExecutionDetail(pipelineId: string, executionId: string) {
   const url = `/api/pipelines/${encodeURIComponent(pipelineId)}/executions/${encodeURIComponent(executionId)}`;
+  const [isRunning, setIsRunning] = useState(true);
 
   const { data, error, isLoading, mutate } =
     useSWR<ExecutionDetailResponse>(url, fetcher, {
       refreshInterval: (latestData) =>
         latestData?.status === "RUNNING" ? 5_000 : 0,
+      revalidateOnFocus: isRunning,
+      onSuccess: (resp) => {
+        setIsRunning(resp.status === "RUNNING");
+      },
     });
 
   return {

--- a/src/hooks/use-pipelines.ts
+++ b/src/hooks/use-pipelines.ts
@@ -1,17 +1,21 @@
-import useSWR from "swr";
+import useSWR, { type SWRConfiguration } from "swr";
 import type { PipelinesListResponse } from "@/lib/types/api";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
-export function usePipelines() {
-  const { data, error, isLoading, mutate } =
+export function usePipelines(
+  options?: Pick<SWRConfiguration<PipelinesListResponse>, "onSuccess">
+) {
+  const { data, error, isLoading, isValidating, mutate } =
     useSWR<PipelinesListResponse>("/api/pipelines", fetcher, {
       refreshInterval: 30_000,
+      ...options,
     });
 
   return {
     pipelines: data?.pipelines,
     isLoading,
+    isValidating,
     error,
     mutate,
   };


### PR DESCRIPTION
## Summary
- Adds "Updated X ago" timestamp next to the Pipelines heading on the overview page, refreshed every 10s via `formatDistanceToNow`
- Adds an amber stale data warning bar when a background SWR refresh fails but cached pipeline data is still displayed — distinct from the existing red error card which only shows when there is no cached data
- Disables `revalidateOnFocus` for completed execution details so tab-switching doesn't trigger unnecessary refetches for immutable data

## Test plan
- [ ] Run `npm run build` — passes with no type errors
- [ ] Run `npm run lint` — no new lint errors (pre-existing warnings unchanged)
- [ ] Dev server: overview page shows "Updated just now" after first load, then relative time ("Updated less than a minute ago", etc.)
- [ ] Simulate network failure: stale amber warning bar appears with retry button; existing red error card only shows on first load failure
- [ ] Open a completed execution detail → switch tabs → verify no refetch occurs in network tab
- [ ] Open a running execution detail → switch tabs → verify refetch still triggers

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)