### PR TITLE
Add loading, error, and empty state components (#13)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,8 +2,10 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { formatDistanceToNow } from "date-fns";
-import { AlertCircle, AlertTriangle, RefreshCw } from "lucide-react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ErrorState } from "@/components/ui/error-state";
+import { EmptyState } from "@/components/ui/empty-state";
 import { usePipelines } from "@/hooks/use-pipelines";
 import { QuickStats, QuickStatsSkeleton } from "@/components/dashboard/quick-stats";
 import { PipelineCard, PipelineCardSkeleton } from "@/components/dashboard/pipeline-card";
@@ -69,19 +71,11 @@ export default function Home() {
       ) : null}
 
       {error && !pipelines ? (
-        <div className="flex flex-col items-center gap-4 rounded-lg border border-red-200 bg-red-50 p-8 text-center">
-          <AlertCircle className="size-8 text-red-500" />
-          <div>
-            <p className="font-medium text-red-800">Failed to load pipelines</p>
-            <p className="text-sm text-red-600">
-              {error.message || "An unexpected error occurred."}
-            </p>
-          </div>
-          <Button variant="outline" size="sm" onClick={() => mutate()}>
-            <RefreshCw className="size-4" />
-            Retry
-          </Button>
-        </div>
+        <ErrorState
+          title="Failed to load pipelines"
+          message={error.message || "An unexpected error occurred."}
+          onRetry={() => mutate()}
+        />
       ) : isLoading ? (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: 6 }).map((_, i) => (
@@ -89,12 +83,10 @@ export default function Home() {
           ))}
         </div>
       ) : pipelines && pipelines.length === 0 ? (
-        <div className="flex flex-col items-center gap-2 rounded-lg border p-8 text-center text-muted-foreground">
-          <p className="font-medium">No pipelines found</p>
-          <p className="text-sm">
-            Pipelines will appear here once they are registered.
-          </p>
-        </div>
+        <EmptyState
+          title="No pipelines found"
+          description="Pipelines will appear here once they are registered."
+        />
       ) : pipelines ? (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
           {pipelines.map((pipeline) => (

--- a/src/app/pipelines/[pipelineId]/executions/[executionId]/page.tsx
+++ b/src/app/pipelines/[pipelineId]/executions/[executionId]/page.tsx
@@ -4,15 +4,12 @@ import { useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import {
-  AlertCircle,
-  RefreshCw,
   ChevronDown,
   ChevronRight,
   Clock,
   ArrowLeft,
 } from "lucide-react";
 import { format, formatDistanceToNow } from "date-fns";
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
   Card,
@@ -20,7 +17,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
+import { ErrorState } from "@/components/ui/error-state";
+import { ExecutionDetailSkeleton } from "@/components/loading/execution-detail-skeleton";
 import { useExecutionDetail } from "@/hooks/use-execution-detail";
 import {
   StatusIcon,
@@ -82,16 +80,6 @@ function CollapsibleJson({
         </CardContent>
       )}
     </Card>
-  );
-}
-
-function DetailSkeleton() {
-  return (
-    <div className="space-y-6">
-      <Skeleton className="h-24 w-full" />
-      <Skeleton className="h-48 w-full" />
-      <Skeleton className="h-64 w-full" />
-    </div>
   );
 }
 
@@ -179,23 +167,13 @@ export default function ExecutionDetailPage() {
       </Link>
 
       {error ? (
-        <div className="flex flex-col items-center gap-4 rounded-lg border border-red-200 bg-red-50 p-8 text-center">
-          <AlertCircle className="size-8 text-red-500" />
-          <div>
-            <p className="font-medium text-red-800">
-              Failed to load execution
-            </p>
-            <p className="text-sm text-red-600">
-              {error.message || "An unexpected error occurred."}
-            </p>
-          </div>
-          <Button variant="outline" size="sm" onClick={() => mutate()}>
-            <RefreshCw className="size-4" />
-            Retry
-          </Button>
-        </div>
+        <ErrorState
+          title="Failed to load execution"
+          message={error.message || "An unexpected error occurred."}
+          onRetry={() => mutate()}
+        />
       ) : isLoading || !execution ? (
-        <DetailSkeleton />
+        <ExecutionDetailSkeleton />
       ) : (
         <div className="space-y-6">
           {/* Header */}

--- a/src/app/pipelines/[pipelineId]/executions/page.tsx
+++ b/src/app/pipelines/[pipelineId]/executions/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { AlertCircle, RefreshCw, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 import { Button } from "@/components/ui/button";
 import {
@@ -20,7 +20,9 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Skeleton } from "@/components/ui/skeleton";
+import { ErrorState } from "@/components/ui/error-state";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ExecutionsSkeleton } from "@/components/loading/executions-skeleton";
 import { useExecutions } from "@/hooks/use-executions";
 import {
   StatusIcon,
@@ -37,16 +39,6 @@ const STATUS_OPTIONS = [
   { value: "TIMED_OUT", label: "Timed Out" },
   { value: "ABORTED", label: "Aborted" },
 ] as const;
-
-function ExecutionsSkeleton() {
-  return (
-    <div className="space-y-3">
-      {Array.from({ length: 5 }).map((_, i) => (
-        <Skeleton key={i} className="h-12 w-full" />
-      ))}
-    </div>
-  );
-}
 
 export default function ExecutionHistoryPage() {
   const params = useParams<{ pipelineId: string }>();
@@ -122,32 +114,22 @@ export default function ExecutionHistoryPage() {
         </CardHeader>
         <CardContent>
           {error ? (
-            <div className="flex flex-col items-center gap-4 rounded-lg border border-red-200 bg-red-50 p-8 text-center">
-              <AlertCircle className="size-8 text-red-500" />
-              <div>
-                <p className="font-medium text-red-800">
-                  Failed to load executions
-                </p>
-                <p className="text-sm text-red-600">
-                  {error.message || "An unexpected error occurred."}
-                </p>
-              </div>
-              <Button variant="outline" size="sm" onClick={() => mutate()}>
-                <RefreshCw className="size-4" />
-                Retry
-              </Button>
-            </div>
+            <ErrorState
+              title="Failed to load executions"
+              message={error.message || "An unexpected error occurred."}
+              onRetry={() => mutate()}
+            />
           ) : isLoading && accumulated.length === 0 ? (
             <ExecutionsSkeleton />
           ) : executions.length === 0 ? (
-            <div className="flex flex-col items-center gap-2 rounded-lg border p-8 text-center text-muted-foreground">
-              <p className="font-medium">No executions found</p>
-              <p className="text-sm">
-                {statusFilter
+            <EmptyState
+              title="No executions found"
+              description={
+                statusFilter
                   ? "Try changing the status filter."
-                  : "This pipeline has no execution history yet."}
-              </p>
-            </div>
+                  : "This pipeline has no execution history yet."
+              }
+            />
           ) : (
             <>
               <Table>

--- a/src/app/pipelines/[pipelineId]/metrics/page.tsx
+++ b/src/app/pipelines/[pipelineId]/metrics/page.tsx
@@ -3,9 +3,9 @@
 import { useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { AlertCircle, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
+import { ErrorState } from "@/components/ui/error-state";
+import { MetricsSkeleton } from "@/components/loading/metrics-skeleton";
 import { useMetrics, type MetricsPagePeriod } from "@/hooks/use-metrics";
 import { SuccessRateChart } from "@/components/metrics/SuccessRateChart";
 import { DurationChart } from "@/components/metrics/DurationChart";
@@ -14,15 +14,6 @@ const PERIODS: { value: MetricsPagePeriod; label: string }[] = [
   { value: "7d", label: "7 days" },
   { value: "30d", label: "30 days" },
 ];
-
-function MetricsSkeleton() {
-  return (
-    <div className="space-y-6">
-      <Skeleton className="h-80 w-full rounded-xl" />
-      <Skeleton className="h-80 w-full rounded-xl" />
-    </div>
-  );
-}
 
 export default function MetricsPage() {
   const params = useParams<{ pipelineId: string }>();
@@ -60,19 +51,11 @@ export default function MetricsPage() {
       </div>
 
       {error ? (
-        <div className="flex flex-col items-center gap-4 rounded-lg border border-red-200 bg-red-50 p-8 text-center">
-          <AlertCircle className="size-8 text-red-500" />
-          <div>
-            <p className="font-medium text-red-800">Failed to load metrics</p>
-            <p className="text-sm text-red-600">
-              {error.message || "An unexpected error occurred."}
-            </p>
-          </div>
-          <Button variant="outline" size="sm" onClick={() => mutate()}>
-            <RefreshCw className="size-4" />
-            Retry
-          </Button>
-        </div>
+        <ErrorState
+          title="Failed to load metrics"
+          message={error.message || "An unexpected error occurred."}
+          onRetry={() => mutate()}
+        />
       ) : isLoading ? (
         <MetricsSkeleton />
       ) : data ? (

--- a/src/app/pipelines/[pipelineId]/page.tsx
+++ b/src/app/pipelines/[pipelineId]/page.tsx
@@ -2,28 +2,15 @@
 
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { AlertCircle, RefreshCw, BarChart3 } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
+import { BarChart3 } from "lucide-react";
+import { ErrorState } from "@/components/ui/error-state";
+import { EmptyState } from "@/components/ui/empty-state";
 import { usePipeline } from "@/hooks/use-pipeline";
+import { PipelineDetailSkeleton } from "@/components/loading/pipeline-detail-skeleton";
 import { PipelineHeader } from "@/components/pipeline/pipeline-header";
 import { SyncStatePanel } from "@/components/pipeline/sync-state-panel";
 import { StreamTable } from "@/components/pipeline/stream-table";
 import { RecentExecutions } from "@/components/pipeline/recent-executions";
-
-function DetailSkeleton() {
-  return (
-    <div className="space-y-6">
-      <div className="space-y-3">
-        <Skeleton className="h-8 w-64" />
-        <Skeleton className="h-4 w-96" />
-      </div>
-      <Skeleton className="h-32 w-full" />
-      <Skeleton className="h-48 w-full" />
-      <Skeleton className="h-64 w-full" />
-    </div>
-  );
-}
 
 export default function PipelineDetailPage() {
   const params = useParams<{ pipelineId: string }>();
@@ -33,30 +20,18 @@ export default function PipelineDetailPage() {
   return (
     <div className="mx-auto max-w-7xl space-y-6 p-6">
       {error ? (
-        <div className="flex flex-col items-center gap-4 rounded-lg border border-red-200 bg-red-50 p-8 text-center">
-          <AlertCircle className="size-8 text-red-500" />
-          <div>
-            <p className="font-medium text-red-800">
-              Failed to load pipeline
-            </p>
-            <p className="text-sm text-red-600">
-              {error.message || "An unexpected error occurred."}
-            </p>
-          </div>
-          <Button variant="outline" size="sm" onClick={() => mutate()}>
-            <RefreshCw className="size-4" />
-            Retry
-          </Button>
-        </div>
+        <ErrorState
+          title="Failed to load pipeline"
+          message={error.message || "An unexpected error occurred."}
+          onRetry={() => mutate()}
+        />
       ) : isLoading ? (
-        <DetailSkeleton />
+        <PipelineDetailSkeleton />
       ) : !pipeline ? (
-        <div className="flex flex-col items-center gap-2 rounded-lg border p-8 text-center text-muted-foreground">
-          <p className="font-medium">Pipeline not found</p>
-          <p className="text-sm">
-            This pipeline may have been removed or you don&apos;t have access.
-          </p>
-        </div>
+        <EmptyState
+          title="Pipeline not found"
+          description="This pipeline may have been removed or you don't have access."
+        />
       ) : (
         <>
           <PipelineHeader pipeline={pipeline} />

--- a/src/components/loading/execution-detail-skeleton.tsx
+++ b/src/components/loading/execution-detail-skeleton.tsx
@@ -1,0 +1,66 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+export function ExecutionDetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      {/* Header card */}
+      <Card>
+        <CardContent className="pt-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex items-start gap-3">
+              <Skeleton className="mt-1 size-5 rounded-full" />
+              <div className="space-y-2">
+                <Skeleton className="h-6 w-64" />
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-5 w-20 rounded-full" />
+                  <Skeleton className="h-4 w-16" />
+                </div>
+              </div>
+            </div>
+            <div className="space-y-1">
+              <Skeleton className="h-4 w-48" />
+              <Skeleton className="h-4 w-44" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* JSON panel placeholder */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-4 w-16" />
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-32 w-full rounded-md" />
+        </CardContent>
+      </Card>
+
+      {/* Timeline */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-4 w-32" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex gap-4">
+                <div className="flex flex-col items-center">
+                  <Skeleton className="mt-1 size-2 rounded-full" />
+                  <Skeleton className="w-px grow" />
+                </div>
+                <div className="flex-1 space-y-1 pb-2">
+                  <div className="flex items-center gap-2">
+                    <Skeleton className="h-4 w-40" />
+                    <Skeleton className="h-4 w-16 rounded-full" />
+                    <Skeleton className="h-3 w-20" />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/loading/executions-skeleton.tsx
+++ b/src/components/loading/executions-skeleton.tsx
@@ -1,0 +1,46 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+export function ExecutionsSkeleton() {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-10">Status</TableHead>
+          <TableHead>Execution ID</TableHead>
+          <TableHead>Started</TableHead>
+          <TableHead>Duration</TableHead>
+          <TableHead className="text-right">Details</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <TableRow key={i}>
+            <TableCell>
+              <Skeleton className="size-5 rounded-full" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-4 w-36" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-4 w-24" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-4 w-16" />
+            </TableCell>
+            <TableCell className="text-right">
+              <Skeleton className="ml-auto h-4 w-10" />
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/components/loading/metrics-skeleton.tsx
+++ b/src/components/loading/metrics-skeleton.tsx
@@ -1,0 +1,19 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+export function MetricsSkeleton() {
+  return (
+    <div className="space-y-6">
+      {Array.from({ length: 2 }).map((_, i) => (
+        <Card key={i}>
+          <CardHeader>
+            <Skeleton className="h-5 w-40" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-64 w-full rounded-md" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/components/loading/pipeline-detail-skeleton.tsx
+++ b/src/components/loading/pipeline-detail-skeleton.tsx
@@ -1,0 +1,90 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+export function PipelineDetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      {/* PipelineHeader skeleton */}
+      <div className="space-y-4">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-8 w-72" />
+          <Skeleton className="h-6 w-20 rounded-full" />
+        </div>
+        <div className="flex gap-6">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-4 w-36" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+      </div>
+
+      {/* SyncStatePanel skeleton */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-24" />
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="h-3 w-16" />
+                <Skeleton className="h-5 w-20" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* StreamTable skeleton */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-20" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            <div className="flex gap-4">
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="h-4 w-16" />
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-4 w-32" />
+            </div>
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex gap-4">
+                <Skeleton className="h-4 w-28" />
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-4 w-32" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* RecentExecutions skeleton */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <Skeleton className="h-5 w-36" />
+          <Skeleton className="h-4 w-28" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            <div className="flex gap-4">
+              <Skeleton className="h-4 w-8" />
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-4 w-16" />
+              <Skeleton className="ml-auto h-4 w-10" />
+            </div>
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex gap-4">
+                <Skeleton className="h-4 w-8" />
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="ml-auto h-4 w-10" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,49 @@
+import type { LucideIcon } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+interface EmptyStateAction {
+  label: string;
+  href?: string;
+  onClick?: () => void;
+}
+
+interface EmptyStateProps {
+  icon?: LucideIcon;
+  title: string;
+  description?: string;
+  action?: EmptyStateAction;
+}
+
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+}: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed p-8 text-center dark:border-muted">
+      {Icon && (
+        <Icon className="size-8 text-muted-foreground/60" />
+      )}
+      <div>
+        <p className="font-medium text-muted-foreground">{title}</p>
+        {description && (
+          <p className="mt-1 text-sm text-muted-foreground/80">
+            {description}
+          </p>
+        )}
+      </div>
+      {action &&
+        (action.href ? (
+          <Button variant="outline" size="sm" asChild>
+            <Link href={action.href}>{action.label}</Link>
+          </Button>
+        ) : action.onClick ? (
+          <Button variant="outline" size="sm" onClick={action.onClick}>
+            {action.label}
+          </Button>
+        ) : null)}
+    </div>
+  );
+}

--- a/src/components/ui/error-state.tsx
+++ b/src/components/ui/error-state.tsx
@@ -1,0 +1,34 @@
+import { AlertCircle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface ErrorStateProps {
+  title?: string;
+  message?: string;
+  onRetry?: () => void;
+}
+
+export function ErrorState({
+  title = "Something went wrong",
+  message,
+  onRetry,
+}: ErrorStateProps) {
+  return (
+    <div className="flex flex-col items-center gap-4 rounded-lg border border-red-200 bg-red-50 p-8 text-center dark:border-red-900 dark:bg-red-950">
+      <AlertCircle className="size-8 text-red-500 dark:text-red-400" />
+      <div>
+        <p className="font-medium text-red-800 dark:text-red-200">{title}</p>
+        {message && (
+          <p className="mt-1 text-sm text-red-600 dark:text-red-300">
+            {message}
+          </p>
+        )}
+      </div>
+      {onRetry && (
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          <RefreshCw className="size-4" />
+          Retry
+        </Button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Extract reusable `<ErrorState>` and `<EmptyState>` components to replace duplicated inline blocks across all 5 pages
- Create higher-fidelity skeleton components (`PipelineDetailSkeleton`, `ExecutionDetailSkeleton`, `ExecutionsSkeleton`, `MetricsSkeleton`) that mirror actual page layouts
- Add dark mode support to error states

## Changes

**New components:**
- `src/components/ui/error-state.tsx` — Reusable error block with title, message, and optional retry button
- `src/components/ui/empty-state.tsx` — Reusable empty state with optional icon, description, and action
- `src/components/loading/pipeline-detail-skeleton.tsx` — Mirrors PipelineHeader + SyncStatePanel + StreamTable + RecentExecutions
- `src/components/loading/execution-detail-skeleton.tsx` — Mirrors header card + JSON panels + timeline
- `src/components/loading/executions-skeleton.tsx` — Proper Table structure with header + 5 skeleton rows
- `src/components/loading/metrics-skeleton.tsx` — Card-wrapped chart placeholders

**Updated pages (5):**
- `src/app/page.tsx` — Uses `ErrorState` + `EmptyState`
- `src/app/pipelines/[pipelineId]/page.tsx` — Uses `ErrorState` + `EmptyState` + `PipelineDetailSkeleton`
- `src/app/pipelines/[pipelineId]/executions/page.tsx` — Uses `ErrorState` + `EmptyState` + `ExecutionsSkeleton`
- `src/app/pipelines/[pipelineId]/executions/[executionId]/page.tsx` — Uses `ErrorState` + `ExecutionDetailSkeleton`
- `src/app/pipelines/[pipelineId]/metrics/page.tsx` — Uses `ErrorState` + `MetricsSkeleton`

## Test plan

- [ ] `npm run build` passes with no errors
- [ ] `npm run lint` has no new warnings (all remaining are pre-existing)
- [ ] Each page shows proper skeleton → loaded content transition
- [ ] Error states render correctly with retry functionality
- [ ] Empty states display appropriate messaging
- [ ] Dark mode styling works for error states

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)