### PR TITLE
Add CloudWatch log viewer (#15)

### DIFF
--- a/src/app/api/pipelines/[pipelineId]/logs/route.ts
+++ b/src/app/api/pipelines/[pipelineId]/logs/route.ts
@@ -1,0 +1,141 @@
+import { NextResponse } from "next/server";
+import { getPipeline } from "@/lib/aws/dynamodb";
+import { getLogs } from "@/lib/aws/logs";
+import {
+  requireAuth,
+  getClientFilter,
+  handleAwsError,
+} from "@/lib/api/helpers";
+import type { LogsResponse, LogEventResponse } from "@/lib/types/api";
+
+const VALID_LOG_GROUPS = new Set(["ecs", "sfn"]);
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 500;
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ pipelineId: string }> }
+) {
+  try {
+    // 1. Authenticate
+    const authResult = await requireAuth();
+    if (authResult.errorResponse) return authResult.errorResponse;
+    const { session } = authResult;
+
+    // 2. Decode pipeline ID
+    const { pipelineId: rawId } = await params;
+    const pipelineId = decodeURIComponent(rawId);
+
+    // 3. Fetch pipeline from registry
+    const pipeline = await getPipeline(pipelineId);
+    if (!pipeline) {
+      return NextResponse.json(
+        { error: "Not Found", message: "Pipeline not found" },
+        { status: 404 }
+      );
+    }
+
+    // 4. Multi-tenant check
+    const allowedClients = getClientFilter(session.user.groups);
+    if (allowedClients && !allowedClients.includes(pipeline.client_name)) {
+      return NextResponse.json(
+        { error: "Not Found", message: "Pipeline not found" },
+        { status: 404 }
+      );
+    }
+
+    // 5. Parse query params
+    const url = new URL(request.url);
+    const logGroup = url.searchParams.get("logGroup");
+    const startTimeParam = url.searchParams.get("startTime");
+    const endTimeParam = url.searchParams.get("endTime");
+    const filter = url.searchParams.get("filter") || undefined;
+    const nextToken = url.searchParams.get("nextToken") || undefined;
+    const limitParam = url.searchParams.get("limit");
+
+    // 6. Validate required params
+    if (!logGroup || !VALID_LOG_GROUPS.has(logGroup)) {
+      return NextResponse.json(
+        {
+          error: "Bad Request",
+          message: 'logGroup is required and must be "ecs" or "sfn"',
+        },
+        { status: 400 }
+      );
+    }
+
+    if (!startTimeParam || !endTimeParam) {
+      return NextResponse.json(
+        {
+          error: "Bad Request",
+          message: "startTime and endTime are required (ISO 8601)",
+        },
+        { status: 400 }
+      );
+    }
+
+    const startTime = new Date(startTimeParam).getTime();
+    const endTime = new Date(endTimeParam).getTime();
+
+    if (isNaN(startTime) || isNaN(endTime)) {
+      return NextResponse.json(
+        {
+          error: "Bad Request",
+          message: "startTime and endTime must be valid ISO 8601 dates",
+        },
+        { status: 400 }
+      );
+    }
+
+    const limit = limitParam
+      ? Math.min(Math.max(1, parseInt(limitParam, 10) || DEFAULT_LIMIT), MAX_LIMIT)
+      : DEFAULT_LIMIT;
+
+    // 7. Resolve log group name
+    const logGroupName =
+      logGroup === "ecs" ? pipeline.ecs_log_group : pipeline.sfn_log_group;
+
+    if (!logGroupName) {
+      return NextResponse.json(
+        {
+          error: "Not Found",
+          message: `No ${logGroup} log group configured for this pipeline`,
+        },
+        { status: 404 }
+      );
+    }
+
+    // 8. Fetch logs
+    const result = await getLogs(
+      logGroupName,
+      startTime,
+      endTime,
+      filter,
+      nextToken,
+      limit
+    );
+
+    // 9. Build response
+    const events: LogEventResponse[] = result.events.map((ev) => ({
+      timestamp: new Date(ev.timestamp).toISOString(),
+      message: ev.message,
+      ingestionTime: ev.ingestionTime
+        ? new Date(ev.ingestionTime).toISOString()
+        : null,
+      eventId: ev.eventId ?? null,
+    }));
+
+    const body: LogsResponse = {
+      events,
+      nextToken: result.nextToken ?? null,
+    };
+
+    return NextResponse.json(body, {
+      headers: {
+        "Cache-Control": "s-maxage=5, stale-while-revalidate=10",
+      },
+    });
+  } catch (error) {
+    return handleAwsError(error);
+  }
+}

--- a/src/app/pipelines/[pipelineId]/executions/[executionId]/page.tsx
+++ b/src/app/pipelines/[pipelineId]/executions/[executionId]/page.tsx
@@ -10,6 +10,7 @@ import {
   ChevronRight,
   Clock,
   ArrowLeft,
+  FileText,
 } from "lucide-react";
 import { format, formatDistanceToNow } from "date-fns";
 import { Button } from "@/components/ui/button";
@@ -252,6 +253,15 @@ export default function ExecutionDetailPage() {
               </div>
             </CardContent>
           </Card>
+
+          {/* View logs link */}
+          <Link
+            href={`/pipelines/${encodeURIComponent(pipelineId)}/logs?startTime=${encodeURIComponent(execution.startDate)}&endTime=${encodeURIComponent(execution.stopDate || new Date().toISOString())}`}
+            className="inline-flex items-center gap-2 text-sm text-blue-600 hover:underline"
+          >
+            <FileText className="size-4" />
+            View Logs for this Execution
+          </Link>
 
           {/* Error panel */}
           {(execution.status === "FAILED" ||

--- a/src/app/pipelines/[pipelineId]/logs/page.tsx
+++ b/src/app/pipelines/[pipelineId]/logs/page.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useState, useCallback, useMemo, useRef, useEffect } from "react";
+import { useParams, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import {
+  AlertCircle,
+  RefreshCw,
+  Search,
+  Loader2,
+  Terminal,
+} from "lucide-react";
+import { format } from "date-fns";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { useLogs, type LogSource } from "@/hooks/use-logs";
+import { LogsSkeleton } from "@/components/loading/logs-skeleton";
+import type { LogEventResponse } from "@/lib/types/api";
+
+const LOG_SOURCES: { value: LogSource; label: string }[] = [
+  { value: "ecs", label: "ECS Container" },
+  { value: "sfn", label: "Step Functions" },
+];
+
+function detectLogLevel(message: string): "error" | "warn" | "info" | "debug" | null {
+  const prefix = message.slice(0, 100).toUpperCase();
+  if (prefix.includes("ERROR") || prefix.includes("FATAL") || prefix.includes("CRITICAL"))
+    return "error";
+  if (prefix.includes("WARN")) return "warn";
+  if (prefix.includes("INFO")) return "info";
+  if (prefix.includes("DEBUG") || prefix.includes("TRACE")) return "debug";
+  return null;
+}
+
+const levelStyles: Record<string, string> = {
+  error: "text-red-400",
+  warn: "text-amber-400",
+  info: "text-emerald-400",
+  debug: "text-zinc-500",
+};
+
+function LogLine({ event }: { event: LogEventResponse }) {
+  const level = detectLogLevel(event.message);
+  const messageClass = level ? levelStyles[level] : "text-zinc-300";
+  const ts = format(new Date(event.timestamp), "HH:mm:ss.SSS");
+
+  return (
+    <div className="group flex gap-3 px-4 py-0.5 hover:bg-white/[0.03] transition-colors">
+      <span className="shrink-0 select-none text-zinc-600 tabular-nums">
+        {ts}
+      </span>
+      <span className={`min-w-0 whitespace-pre-wrap break-all ${messageClass}`}>
+        {event.message}
+      </span>
+    </div>
+  );
+}
+
+export default function LogViewerPage() {
+  const params = useParams<{ pipelineId: string }>();
+  const searchParams = useSearchParams();
+  const pipelineId = decodeURIComponent(params.pipelineId);
+
+  // Time range from query params or default to last 24 hours
+  const qStart = searchParams.get("startTime");
+  const qEnd = searchParams.get("endTime");
+
+  const [defaultStart] = useState(
+    () => new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+  );
+  const [defaultEnd] = useState(() => new Date().toISOString());
+
+  const startTime = qStart || defaultStart;
+  const endTime = qEnd || defaultEnd;
+
+  const [logSource, setLogSource] = useState<LogSource>("ecs");
+  const [filterInput, setFilterInput] = useState("");
+  const [activeFilter, setActiveFilter] = useState<string | undefined>(
+    undefined
+  );
+
+  // Pagination accumulation
+  const [accumulated, setAccumulated] = useState<LogEventResponse[]>([]);
+  const [currentToken, setCurrentToken] = useState<string | undefined>(
+    undefined
+  );
+
+  const { data, isLoading, error, mutate } = useLogs({
+    pipelineId,
+    logSource,
+    startTime,
+    endTime,
+    filter: activeFilter,
+    nextToken: currentToken,
+  });
+
+  // Merge pages
+  const events = useMemo(
+    () =>
+      currentToken && accumulated.length > 0
+        ? [...accumulated, ...(data?.events ?? [])]
+        : (data?.events ?? []),
+    [currentToken, accumulated, data?.events]
+  );
+
+  const handleLoadMore = useCallback(() => {
+    if (data?.nextToken) {
+      setAccumulated(events);
+      setCurrentToken(data.nextToken);
+    }
+  }, [data, events]);
+
+  const handleSearch = useCallback(() => {
+    setAccumulated([]);
+    setCurrentToken(undefined);
+    setActiveFilter(filterInput || undefined);
+  }, [filterInput]);
+
+  const handleSourceChange = useCallback(
+    (source: LogSource) => {
+      setLogSource(source);
+      setAccumulated([]);
+      setCurrentToken(undefined);
+    },
+    []
+  );
+
+  const handleRefresh = useCallback(() => {
+    setAccumulated([]);
+    setCurrentToken(undefined);
+    mutate();
+  }, [mutate]);
+
+  // Scroll container ref for auto-scroll on new data
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const prevEventCount = useRef(0);
+  useEffect(() => {
+    if (events.length > prevEventCount.current && scrollRef.current) {
+      // Only auto-scroll if user was already near the bottom
+      const el = scrollRef.current;
+      const isNearBottom =
+        el.scrollHeight - el.scrollTop - el.clientHeight < 100;
+      if (isNearBottom) {
+        el.scrollTop = el.scrollHeight;
+      }
+    }
+    prevEventCount.current = events.length;
+  }, [events.length]);
+
+  const timeRangeLabel = qStart
+    ? `${format(new Date(startTime), "MMM d, HH:mm:ss")} — ${format(new Date(endTime), "MMM d, HH:mm:ss")}`
+    : "Last 24 hours";
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6 p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Logs</h1>
+          <p className="text-muted-foreground text-sm">{pipelineId}</p>
+        </div>
+        <Link
+          href={`/pipelines/${encodeURIComponent(pipelineId)}`}
+          className="text-sm text-blue-600 hover:underline"
+        >
+          Back to pipeline
+        </Link>
+      </div>
+
+      {/* Controls row */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-1">
+          {LOG_SOURCES.map((s) => (
+            <Button
+              key={s.value}
+              variant={logSource === s.value ? "default" : "outline"}
+              size="sm"
+              onClick={() => handleSourceChange(s.value)}
+            >
+              {s.label}
+            </Button>
+          ))}
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="relative">
+            <Search className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={filterInput}
+              onChange={(e) => setFilterInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleSearch();
+              }}
+              placeholder="Filter pattern..."
+              className="h-9 w-64 pl-9"
+            />
+          </div>
+          <Button variant="outline" size="sm" onClick={handleSearch}>
+            Search
+          </Button>
+        </div>
+      </div>
+
+      {/* Time range */}
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Badge variant="secondary" className="font-mono text-xs">
+          {timeRangeLabel}
+        </Badge>
+        {activeFilter && (
+          <Badge variant="outline" className="font-mono text-xs">
+            filter: {activeFilter}
+          </Badge>
+        )}
+      </div>
+
+      {/* Log output */}
+      {error ? (
+        <div className="flex flex-col items-center gap-4 rounded-lg border border-red-200 bg-red-50 p-8 text-center">
+          <AlertCircle className="size-8 text-red-500" />
+          <div>
+            <p className="font-medium text-red-800">Failed to load logs</p>
+            <p className="text-sm text-red-600">
+              {error.message || "An unexpected error occurred."}
+            </p>
+          </div>
+          <Button variant="outline" size="sm" onClick={() => mutate()}>
+            <RefreshCw className="size-4" />
+            Retry
+          </Button>
+        </div>
+      ) : (
+        <Card className="overflow-hidden">
+          <CardHeader className="flex flex-row items-center justify-between border-b bg-zinc-950/[0.02] dark:bg-zinc-950/50">
+            <CardTitle className="flex items-center gap-2 text-sm">
+              <Terminal className="size-4 text-muted-foreground" />
+              Log Output
+              {events.length > 0 && (
+                <span className="text-xs font-normal text-muted-foreground">
+                  ({events.length} events)
+                </span>
+              )}
+            </CardTitle>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleRefresh}
+              disabled={isLoading}
+            >
+              <RefreshCw
+                className={`size-4 ${isLoading ? "animate-spin" : ""}`}
+              />
+            </Button>
+          </CardHeader>
+          <CardContent className="p-0">
+            {isLoading && accumulated.length === 0 ? (
+              <LogsSkeleton />
+            ) : events.length === 0 ? (
+              <div className="flex flex-col items-center gap-2 p-12 text-center text-muted-foreground">
+                <Terminal className="size-8 opacity-40" />
+                <p className="font-medium">No log events found</p>
+                <p className="text-sm">
+                  {activeFilter
+                    ? "Try a different filter pattern or time range."
+                    : "No events in this time range."}
+                </p>
+              </div>
+            ) : (
+              <>
+                <div
+                  ref={scrollRef}
+                  className="max-h-[600px] overflow-y-auto bg-zinc-950 font-mono text-xs leading-relaxed"
+                >
+                  {events.map((event, i) => (
+                    <LogLine key={event.eventId ?? i} event={event} />
+                  ))}
+                </div>
+                {data?.nextToken && (
+                  <div className="flex justify-center border-t bg-zinc-950/[0.02] p-3 dark:bg-zinc-950/50">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleLoadMore}
+                      disabled={isLoading}
+                    >
+                      {isLoading ? (
+                        <Loader2 className="size-4 animate-spin" />
+                      ) : null}
+                      Load More
+                    </Button>
+                  </div>
+                )}
+              </>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/pipelines/[pipelineId]/page.tsx
+++ b/src/app/pipelines/[pipelineId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { AlertCircle, RefreshCw, BarChart3 } from "lucide-react";
+import { AlertCircle, RefreshCw, BarChart3, FileText } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { usePipeline } from "@/hooks/use-pipeline";
@@ -68,13 +68,22 @@ export default function PipelineDetailPage() {
             executions={pipeline.recentExecutions}
             pipelineId={pipeline.pipelineId}
           />
-          <Link
-            href={`/pipelines/${encodeURIComponent(pipeline.pipelineId)}/metrics`}
-            className="inline-flex items-center gap-2 text-sm text-blue-600 hover:underline"
-          >
-            <BarChart3 className="size-4" />
-            View Metrics
-          </Link>
+          <div className="flex items-center gap-4">
+            <Link
+              href={`/pipelines/${encodeURIComponent(pipeline.pipelineId)}/metrics`}
+              className="inline-flex items-center gap-2 text-sm text-blue-600 hover:underline"
+            >
+              <BarChart3 className="size-4" />
+              View Metrics
+            </Link>
+            <Link
+              href={`/pipelines/${encodeURIComponent(pipeline.pipelineId)}/logs`}
+              className="inline-flex items-center gap-2 text-sm text-blue-600 hover:underline"
+            >
+              <FileText className="size-4" />
+              View Logs
+            </Link>
+          </div>
         </>
       )}
     </div>

--- a/src/components/layout/breadcrumb-nav.tsx
+++ b/src/components/layout/breadcrumb-nav.tsx
@@ -126,6 +126,38 @@ export function BreadcrumbNav() {
     );
   }
 
+  // /pipelines/[id]/logs → Pipelines > id > Logs
+  const logsMatch = pathname.match(
+    /^\/pipelines\/([^/]+)\/logs$/
+  );
+
+  if (logsMatch) {
+    const pipelineId = decodeURIComponent(logsMatch[1]);
+    return (
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href="/">Pipelines</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href={`/pipelines/${encodeURIComponent(pipelineId)}`}>
+                {pipelineId}
+              </Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Logs</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+    );
+  }
+
   // /pipelines/[id] → ["Pipelines", decoded id]
   const pipelineMatch = pathname.match(/^\/pipelines\/([^/]+)/)
 

--- a/src/components/loading/logs-skeleton.tsx
+++ b/src/components/loading/logs-skeleton.tsx
@@ -1,0 +1,29 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+const ROW_WIDTHS = [
+  "w-3/4",
+  "w-1/2",
+  "w-5/6",
+  "w-2/3",
+  "w-4/5",
+  "w-1/3",
+  "w-3/5",
+  "w-5/6",
+  "w-2/5",
+  "w-3/4",
+  "w-1/2",
+  "w-4/5",
+];
+
+export function LogsSkeleton() {
+  return (
+    <div className="space-y-1.5 bg-zinc-950 p-4">
+      {ROW_WIDTHS.map((width, i) => (
+        <div key={i} className="flex gap-3">
+          <Skeleton className="h-4 w-20 shrink-0 bg-zinc-800" />
+          <Skeleton className={`h-4 ${width} bg-zinc-800`} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/use-logs.ts
+++ b/src/hooks/use-logs.ts
@@ -1,0 +1,49 @@
+import useSWR from "swr";
+import type { LogsResponse } from "@/lib/types/api";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export type LogSource = "ecs" | "sfn";
+
+export interface UseLogsOptions {
+  pipelineId: string;
+  logSource: LogSource;
+  startTime: string | null;
+  endTime: string | null;
+  filter?: string;
+  nextToken?: string;
+}
+
+export function useLogs({
+  pipelineId,
+  logSource,
+  startTime,
+  endTime,
+  filter,
+  nextToken,
+}: UseLogsOptions) {
+  const params = new URLSearchParams();
+  params.set("logGroup", logSource);
+  if (startTime) params.set("startTime", startTime);
+  if (endTime) params.set("endTime", endTime);
+  if (filter) params.set("filter", filter);
+  if (nextToken) params.set("nextToken", nextToken);
+
+  const url = `/api/pipelines/${encodeURIComponent(pipelineId)}/logs?${params.toString()}`;
+
+  const { data, error, isLoading, mutate } = useSWR<LogsResponse>(
+    startTime && endTime ? url : null,
+    fetcher,
+    {
+      refreshInterval: 0,
+      revalidateOnFocus: false,
+    }
+  );
+
+  return {
+    data,
+    isLoading,
+    error,
+    mutate,
+  };
+}

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -104,6 +104,20 @@ export interface ExecutionDetailResponse {
   history: ExecutionHistoryEventResponse[];
 }
 
+// ── Logs endpoint ──
+
+export interface LogEventResponse {
+  timestamp: string; // ISO 8601
+  message: string;
+  ingestionTime: string | null;
+  eventId: string | null;
+}
+
+export interface LogsResponse {
+  events: LogEventResponse[];
+  nextToken: string | null;
+}
+
 // ── Pipeline detail endpoint ──
 
 export interface PipelineDetailResponse {


### PR DESCRIPTION
## Summary
- Adds a new log viewer page at `/pipelines/[id]/logs` for viewing CloudWatch logs (ECS container and Step Functions)
- New API route resolves log group names from the pipeline registry, validates params, and proxies CloudWatch `FilterLogEvents`
- SWR hook with on-demand fetching (no auto-refresh) and pagination support
- Terminal-style dark UI with color-coded log levels (ERROR/WARN/INFO/DEBUG), filter pattern search, and log source toggle
- Navigation links from pipeline detail ("View Logs") and execution detail ("View Logs for this Execution" with time-bounded query params)
- Breadcrumb navigation for the logs route

## Test plan
- [ ] Navigate to pipeline detail → click "View Logs" → see last 24h of ECS logs
- [ ] Navigate to execution detail → click "View Logs for this Execution" → see time-bounded logs
- [ ] Toggle between ECS and SFN log sources
- [ ] Enter a filter pattern and search
- [ ] Click "Load More" if logs are paginated
- [ ] Verify error/empty states render correctly
- [ ] `npm run build` passes
- [ ] `npm run lint` has no new warnings

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)