### PR TITLE
Add manual sync trigger for admin users

### DIFF
--- a/src/app/api/pipelines/[pipelineId]/trigger/route.ts
+++ b/src/app/api/pipelines/[pipelineId]/trigger/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+import { getPipeline } from "@/lib/aws/dynamodb";
+import { isCurrentlyRunning, startExecution } from "@/lib/aws/stepfunctions";
+import {
+  requireAuth,
+  isAdmin,
+  getClientFilter,
+  handleAwsError,
+} from "@/lib/api/helpers";
+import type { TriggerSyncResponse } from "@/lib/types/api";
+
+// In-memory rate limit: 60s cooldown per pipeline
+const lastTriggerTime = new Map<string, number>();
+const COOLDOWN_MS = 60_000;
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ pipelineId: string }> }
+) {
+  try {
+    // 1. Authenticate
+    const authResult = await requireAuth();
+    if (authResult.errorResponse) return authResult.errorResponse;
+    const { session } = authResult;
+
+    // 2. Admin check
+    if (!isAdmin(session.user.groups)) {
+      return NextResponse.json(
+        { error: "Forbidden", message: "Only admins can trigger syncs" },
+        { status: 403 }
+      );
+    }
+
+    // 3. Decode pipeline ID
+    const { pipelineId: rawId } = await params;
+    const pipelineId = decodeURIComponent(rawId);
+
+    // 4. Fetch pipeline
+    const pipeline = await getPipeline(pipelineId);
+    if (!pipeline) {
+      return NextResponse.json(
+        { error: "Not Found", message: "Pipeline not found" },
+        { status: 404 }
+      );
+    }
+
+    // 5. Multi-tenant check (defense-in-depth)
+    const allowedClients = getClientFilter(session.user.groups);
+    if (allowedClients && !allowedClients.includes(pipeline.client_name)) {
+      return NextResponse.json(
+        { error: "Not Found", message: "Pipeline not found" },
+        { status: 404 }
+      );
+    }
+
+    // 6. Pipeline must be enabled
+    if (!pipeline.enabled) {
+      return NextResponse.json(
+        {
+          error: "Bad Request",
+          message: "Cannot trigger a disabled pipeline",
+        },
+        { status: 400 }
+      );
+    }
+
+    // 7. Rate limit (60s cooldown per pipeline)
+    const now = Date.now();
+    const lastTrigger = lastTriggerTime.get(pipelineId);
+    if (lastTrigger && now - lastTrigger < COOLDOWN_MS) {
+      const retryAfter = Math.ceil((COOLDOWN_MS - (now - lastTrigger)) / 1000);
+      return NextResponse.json(
+        {
+          error: "Too Many Requests",
+          message: `Please wait ${retryAfter}s before triggering again`,
+        },
+        { status: 429, headers: { "Retry-After": String(retryAfter) } }
+      );
+    }
+
+    // 8. Check if already running
+    const running = await isCurrentlyRunning(pipeline.state_machine_arn);
+    if (running) {
+      return NextResponse.json(
+        {
+          error: "Conflict",
+          message: "An execution is already running for this pipeline",
+        },
+        { status: 409 }
+      );
+    }
+
+    // 9. Start execution with audit info
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const shortId = randomUUID().slice(0, 8);
+    const executionName = `manual-${timestamp}-${shortId}`;
+
+    const input = JSON.stringify({
+      triggeredBy: session.user.email ?? session.user.id,
+      triggeredAt: new Date().toISOString(),
+      source: "dashboard",
+    });
+
+    const result = await startExecution({
+      stateMachineArn: pipeline.state_machine_arn,
+      name: executionName,
+      input,
+    });
+
+    // 10. Record trigger time for rate limiting
+    lastTriggerTime.set(pipelineId, Date.now());
+
+    const body: TriggerSyncResponse = {
+      executionArn: result.executionArn,
+      executionName,
+      startDate: result.startDate.toISOString(),
+    };
+
+    return NextResponse.json(body, { status: 201 });
+  } catch (error) {
+    return handleAwsError(error);
+  }
+}

--- a/src/app/pipelines/[pipelineId]/page.tsx
+++ b/src/app/pipelines/[pipelineId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useParams } from "next/navigation";
+import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { AlertCircle, RefreshCw, BarChart3, FileText } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -29,6 +30,8 @@ export default function PipelineDetailPage() {
   const params = useParams<{ pipelineId: string }>();
   const pipelineId = decodeURIComponent(params.pipelineId);
   const { pipeline, isLoading, error, mutate } = usePipeline(pipelineId);
+  const { data: session } = useSession();
+  const isAdmin = session?.user?.groups?.includes("Admin") ?? false;
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 p-6">
@@ -59,7 +62,7 @@ export default function PipelineDetailPage() {
         </div>
       ) : (
         <>
-          <PipelineHeader pipeline={pipeline} />
+          <PipelineHeader pipeline={pipeline} isAdmin={isAdmin} onTriggered={() => mutate()} />
           <SyncStatePanel syncState={pipeline.syncState} />
           {pipeline.syncState && (
             <StreamTable streams={pipeline.syncState.streams} />

--- a/src/components/pipeline/pipeline-header.tsx
+++ b/src/components/pipeline/pipeline-header.tsx
@@ -2,28 +2,46 @@
 
 import { Badge } from "@/components/ui/badge";
 import { StatusBadge } from "@/components/dashboard/status-badge";
+import { TriggerSyncButton } from "@/components/pipeline/trigger-sync-button";
 import { formatDistanceToNow } from "date-fns";
 import type { PipelineDetailResponse } from "@/lib/types/api";
 
 interface PipelineHeaderProps {
   pipeline: PipelineDetailResponse;
+  isAdmin: boolean;
+  onTriggered: () => void;
 }
 
-export function PipelineHeader({ pipeline }: PipelineHeaderProps) {
+export function PipelineHeader({
+  pipeline,
+  isAdmin,
+  onTriggered,
+}: PipelineHeaderProps) {
   return (
     <div className="space-y-4">
-      <div className="flex items-center gap-3">
-        <h1 className="text-2xl font-bold tracking-tight">
-          {pipeline.clientName}
-          <span className="text-muted-foreground font-normal"> / </span>
-          {pipeline.connectorType}
-        </h1>
-        <StatusBadge status={pipeline.status} />
-        {!pipeline.enabled && (
-          <Badge variant="outline" className="text-muted-foreground">
-            Disabled
-          </Badge>
-        )}
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <h1 className="text-2xl font-bold tracking-tight">
+            {pipeline.clientName}
+            <span className="text-muted-foreground font-normal"> / </span>
+            {pipeline.connectorType}
+          </h1>
+          <StatusBadge status={pipeline.status} />
+          {!pipeline.enabled && (
+            <Badge variant="outline" className="text-muted-foreground">
+              Disabled
+            </Badge>
+          )}
+        </div>
+
+        <TriggerSyncButton
+          pipelineId={pipeline.pipelineId}
+          pipelineName={`${pipeline.clientName} / ${pipeline.connectorType}`}
+          isAdmin={isAdmin}
+          isDisabled={!pipeline.enabled}
+          isRunning={pipeline.isCurrentlyRunning}
+          onTriggered={onTriggered}
+        />
       </div>
 
       <div className="text-muted-foreground flex flex-wrap gap-x-6 gap-y-1 text-sm">

--- a/src/components/pipeline/trigger-sync-button.tsx
+++ b/src/components/pipeline/trigger-sync-button.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Play, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { ApiErrorResponse } from "@/lib/types/api";
+
+interface TriggerSyncButtonProps {
+  pipelineId: string;
+  pipelineName: string;
+  isAdmin: boolean;
+  isDisabled: boolean;
+  isRunning: boolean;
+  onTriggered: () => void;
+}
+
+export function TriggerSyncButton({
+  pipelineId,
+  pipelineName,
+  isAdmin,
+  isDisabled,
+  isRunning,
+  onTriggered,
+}: TriggerSyncButtonProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canTrigger = isAdmin && !isDisabled && !isRunning;
+
+  const tooltipMessage = !isAdmin
+    ? "Only admins can trigger syncs"
+    : isDisabled
+      ? "Pipeline is disabled"
+      : isRunning
+        ? "An execution is already running"
+        : null;
+
+  const handleTrigger = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(
+        `/api/pipelines/${encodeURIComponent(pipelineId)}/trigger`,
+        { method: "POST" }
+      );
+
+      if (!res.ok) {
+        const body = (await res.json()) as ApiErrorResponse;
+        setError(body.message);
+        return;
+      }
+
+      setDialogOpen(false);
+      onTriggered();
+    } catch {
+      setError("Failed to trigger sync. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }, [pipelineId, onTriggered]);
+
+  const button = (
+    <Button
+      variant="outline"
+      size="sm"
+      disabled={!canTrigger || loading}
+      onClick={() => {
+        setError(null);
+        setDialogOpen(true);
+      }}
+      className={
+        canTrigger
+          ? "border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 hover:text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-400 dark:hover:bg-emerald-950/60"
+          : undefined
+      }
+    >
+      {loading ? (
+        <Loader2 className="size-3.5 animate-spin" />
+      ) : (
+        <Play className="size-3.5" />
+      )}
+      Run Now
+    </Button>
+  );
+
+  return (
+    <>
+      {tooltipMessage ? (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span tabIndex={0}>{button}</span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={6}>
+              {tooltipMessage}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : (
+        button
+      )}
+
+      <AlertDialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Trigger manual sync</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will start a new execution for{" "}
+              <span className="font-medium text-foreground">
+                {pipelineName}
+              </span>
+              . The pipeline will run immediately outside its normal schedule.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          {error && (
+            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-400">
+              {error}
+            </div>
+          )}
+
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={loading}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={loading}
+              onClick={(e) => {
+                e.preventDefault();
+                handleTrigger();
+              }}
+              className="bg-emerald-600 text-white hover:bg-emerald-700 dark:bg-emerald-600 dark:hover:bg-emerald-700"
+            >
+              {loading ? (
+                <>
+                  <Loader2 className="size-3.5 animate-spin" />
+                  Starting...
+                </>
+              ) : (
+                <>
+                  <Play className="size-3.5" />
+                  Start Execution
+                </>
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,196 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "bg-muted mb-2 inline-flex size-16 items-center justify-center rounded-md sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Action
+        data-slot="alert-dialog-action"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Cancel
+        data-slot="alert-dialog-cancel"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/src/lib/api/helpers.ts
+++ b/src/lib/api/helpers.ts
@@ -7,6 +7,10 @@ import type { PipelineStatus, LastSyncSummary } from "@/lib/types/api";
 
 // ── Auth helpers ──
 
+export function isAdmin(groups: string[]): boolean {
+  return groups.includes("Admin");
+}
+
 interface AuthResult {
   session: Session;
   errorResponse?: never;

--- a/src/lib/aws/stepfunctions.ts
+++ b/src/lib/aws/stepfunctions.ts
@@ -2,6 +2,7 @@ import {
   ListExecutionsCommand,
   DescribeExecutionCommand,
   GetExecutionHistoryCommand,
+  StartExecutionCommand,
 } from "@aws-sdk/client-sfn";
 import type { HistoryEvent } from "@aws-sdk/client-sfn";
 import { getSFNClient } from "./client";
@@ -121,6 +122,40 @@ function flattenHistoryEvent(ev: HistoryEvent): ExecutionHistoryEvent {
   }
 
   return event;
+}
+
+export interface StartExecutionInput {
+  stateMachineArn: string;
+  name: string;
+  input: string;
+}
+
+export interface StartExecutionResult {
+  executionArn: string;
+  startDate: Date;
+}
+
+export async function startExecution(
+  params: StartExecutionInput
+): Promise<StartExecutionResult> {
+  const client = getSFNClient();
+
+  try {
+    const result = await client.send(
+      new StartExecutionCommand({
+        stateMachineArn: params.stateMachineArn,
+        name: params.name,
+        input: params.input,
+      })
+    );
+
+    return {
+      executionArn: result.executionArn!,
+      startDate: result.startDate!,
+    };
+  } catch (error) {
+    throw new AwsServiceError("StepFunctions", "StartExecution", error);
+  }
 }
 
 export async function isCurrentlyRunning(

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -118,6 +118,14 @@ export interface LogsResponse {
   nextToken: string | null;
 }
 
+// ── Trigger sync endpoint ──
+
+export interface TriggerSyncResponse {
+  executionArn: string;
+  executionName: string;
+  startDate: string; // ISO 8601
+}
+
 // ── Pipeline detail endpoint ──
 
 export interface PipelineDetailResponse {


### PR DESCRIPTION
## Summary

- Adds a "Run Now" button to the pipeline detail page header that lets admin users manually trigger a Step Functions execution
- Includes AlertDialog confirmation, 60s per-pipeline rate limiting, and guards for disabled/already-running pipelines
- Embeds audit info (`triggeredBy`, `triggeredAt`, `source: "dashboard"`) in the execution input for traceability

## Changes

- **`src/lib/api/helpers.ts`** — `isAdmin()` helper checking for `"Admin"` Cognito group
- **`src/lib/aws/stepfunctions.ts`** — `startExecution()` wrapper around `StartExecutionCommand`
- **`src/lib/types/api.ts`** — `TriggerSyncResponse` type
- **`src/app/api/pipelines/[pipelineId]/trigger/route.ts`** — POST endpoint with auth, admin check, multi-tenant check, enabled check, rate limit (60s), running check, then starts execution
- **`src/components/ui/alert-dialog.tsx`** — shadcn alert-dialog component
- **`src/components/pipeline/trigger-sync-button.tsx`** — Client component with emerald-themed button, confirmation dialog, loading/error states, tooltip-wrapped disabled states
- **`src/components/pipeline/pipeline-header.tsx`** — Integrated trigger button, right-aligned in title row
- **`src/app/pipelines/[pipelineId]/page.tsx`** — Passes `isAdmin` (from session) and `mutate` to header

## IAM Note

The dashboard IAM user needs `states:StartExecution` permission on the pipeline state machines. If missing, the API will return 502 (handled by existing `handleAwsError`).

## Test plan

- [ ] Log in as admin → "Run Now" button is enabled on an active pipeline
- [ ] Click "Run Now" → confirmation dialog appears → confirm → execution starts, status updates to "running"
- [ ] Try triggering again within 60s → 429 rate limit message
- [ ] Navigate to a disabled pipeline → button disabled with "Pipeline is disabled" tooltip
- [ ] Log in as non-admin → button disabled with "Only admins can trigger syncs" tooltip
- [ ] Check execution detail → input JSON shows `triggeredBy` audit info

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)