### PR TITLE
Add stream-level detail view (#18)

### DIFF
--- a/src/app/pipelines/[pipelineId]/page.tsx
+++ b/src/app/pipelines/[pipelineId]/page.tsx
@@ -3,7 +3,7 @@
 import { useParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { AlertCircle, RefreshCw, BarChart3, FileText } from "lucide-react";
+import { AlertCircle, RefreshCw, BarChart3, FileText, Database } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { usePipeline } from "@/hooks/use-pipeline";
@@ -65,13 +65,20 @@ export default function PipelineDetailPage() {
           <PipelineHeader pipeline={pipeline} isAdmin={isAdmin} onTriggered={() => mutate()} />
           <SyncStatePanel syncState={pipeline.syncState} />
           {pipeline.syncState && (
-            <StreamTable streams={pipeline.syncState.streams} />
+            <StreamTable streams={pipeline.syncState.streams} pipelineId={pipeline.pipelineId} />
           )}
           <RecentExecutions
             executions={pipeline.recentExecutions}
             pipelineId={pipeline.pipelineId}
           />
           <div className="flex items-center gap-4">
+            <Link
+              href={`/pipelines/${encodeURIComponent(pipeline.pipelineId)}/streams`}
+              className="inline-flex items-center gap-2 text-sm text-blue-600 hover:underline"
+            >
+              <Database className="size-4" />
+              View Streams
+            </Link>
             <Link
               href={`/pipelines/${encodeURIComponent(pipeline.pipelineId)}/metrics`}
               className="inline-flex items-center gap-2 text-sm text-blue-600 hover:underline"

--- a/src/app/pipelines/[pipelineId]/streams/page.tsx
+++ b/src/app/pipelines/[pipelineId]/streams/page.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { AlertCircle, RefreshCw, Database } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { usePipeline } from "@/hooks/use-pipeline";
+import { StreamStats } from "@/components/streams/stream-stats";
+import { RecordCountChart } from "@/components/streams/record-count-chart";
+import { EnhancedStreamTable } from "@/components/streams/enhanced-stream-table";
+
+function StreamsSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <Skeleton className="h-20 w-full" />
+        <Skeleton className="h-20 w-full" />
+        <Skeleton className="h-20 w-full" />
+      </div>
+      <Skeleton className="h-64 w-full" />
+      <Skeleton className="h-80 w-full" />
+    </div>
+  );
+}
+
+export default function StreamsPage() {
+  const params = useParams<{ pipelineId: string }>();
+  const pipelineId = decodeURIComponent(params.pipelineId);
+  const { pipeline, isLoading, error, mutate } = usePipeline(pipelineId);
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6 p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
+            <Database className="size-6 text-muted-foreground" />
+            Streams
+          </h1>
+          <p className="text-sm text-muted-foreground">{pipelineId}</p>
+        </div>
+        <Link
+          href={`/pipelines/${encodeURIComponent(pipelineId)}`}
+          className="text-sm text-blue-600 hover:underline"
+        >
+          Back to pipeline
+        </Link>
+      </div>
+
+      {/* Content */}
+      {error ? (
+        <div className="flex flex-col items-center gap-4 rounded-lg border border-red-200 bg-red-50 p-8 text-center">
+          <AlertCircle className="size-8 text-red-500" />
+          <div>
+            <p className="font-medium text-red-800">
+              Failed to load pipeline
+            </p>
+            <p className="text-sm text-red-600">
+              {error.message || "An unexpected error occurred."}
+            </p>
+          </div>
+          <Button variant="outline" size="sm" onClick={() => mutate()}>
+            <RefreshCw className="size-4" />
+            Retry
+          </Button>
+        </div>
+      ) : isLoading ? (
+        <StreamsSkeleton />
+      ) : !pipeline ? (
+        <div className="flex flex-col items-center gap-2 rounded-lg border p-8 text-center text-muted-foreground">
+          <p className="font-medium">Pipeline not found</p>
+          <p className="text-sm">
+            This pipeline may have been removed or you don&apos;t have access.
+          </p>
+        </div>
+      ) : !pipeline.syncState ? (
+        <div className="flex flex-col items-center gap-2 rounded-lg border p-8 text-center text-muted-foreground">
+          <Database className="size-8 opacity-40" />
+          <p className="font-medium">No sync state available</p>
+          <p className="text-sm">
+            This pipeline hasn&apos;t completed a sync yet, or sync state data
+            is unavailable.
+          </p>
+        </div>
+      ) : (
+        <>
+          <StreamStats
+            streams={pipeline.syncState.streams}
+            lastSyncTimestamp={pipeline.syncState.lastSyncTimestamp}
+          />
+          <RecordCountChart streams={pipeline.syncState.streams} />
+          <EnhancedStreamTable streams={pipeline.syncState.streams} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/breadcrumb-nav.tsx
+++ b/src/components/layout/breadcrumb-nav.tsx
@@ -158,6 +158,38 @@ export function BreadcrumbNav() {
     );
   }
 
+  // /pipelines/[id]/streams → Pipelines > id > Streams
+  const streamsMatch = pathname.match(
+    /^\/pipelines\/([^/]+)\/streams$/
+  );
+
+  if (streamsMatch) {
+    const pipelineId = decodeURIComponent(streamsMatch[1]);
+    return (
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href="/">Pipelines</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href={`/pipelines/${encodeURIComponent(pipelineId)}`}>
+                {pipelineId}
+              </Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Streams</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+    );
+  }
+
   // /pipelines/[id] → ["Pipelines", decoded id]
   const pipelineMatch = pathname.match(/^\/pipelines\/([^/]+)/)
 

--- a/src/components/pipeline/stream-table.tsx
+++ b/src/components/pipeline/stream-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import {
   Card,
   CardContent,
@@ -18,9 +19,10 @@ import type { StreamSummary } from "@/lib/types/api";
 
 interface StreamTableProps {
   streams: StreamSummary[];
+  pipelineId: string;
 }
 
-export function StreamTable({ streams }: StreamTableProps) {
+export function StreamTable({ streams, pipelineId }: StreamTableProps) {
   if (streams.length === 0) {
     return (
       <Card>
@@ -38,8 +40,14 @@ export function StreamTable({ streams }: StreamTableProps) {
 
   return (
     <Card>
-      <CardHeader>
+      <CardHeader className="flex flex-row items-center justify-between">
         <CardTitle>Streams</CardTitle>
+        <Link
+          href={`/pipelines/${encodeURIComponent(pipelineId)}/streams`}
+          className="text-sm text-blue-600 hover:underline"
+        >
+          View all
+        </Link>
       </CardHeader>
       <CardContent>
         <Table>

--- a/src/components/streams/enhanced-stream-table.tsx
+++ b/src/components/streams/enhanced-stream-table.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { ChevronRight, ChevronDown } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import type { StreamSummary } from "@/lib/types/api";
+
+interface EnhancedStreamTableProps {
+  streams: StreamSummary[];
+}
+
+export function EnhancedStreamTable({ streams }: EnhancedStreamTableProps) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const toggleExpanded = useCallback((name: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  }, []);
+
+  if (streams.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Stream Details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            No stream data available
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Stream Details</CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-8" />
+              <TableHead>Stream Name</TableHead>
+              <TableHead>Sync Mode</TableHead>
+              <TableHead className="text-right">Records</TableHead>
+              <TableHead>Cursor Field</TableHead>
+              <TableHead>Cursor Value</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {streams.map((stream) => {
+              const isExpanded = expanded.has(stream.name);
+              const hasState =
+                stream.streamState != null &&
+                Object.keys(stream.streamState).length > 0;
+
+              return (
+                <TableRow key={stream.name} className="group">
+                  <TableCell className="w-8 px-2">
+                    {hasState ? (
+                      <button
+                        onClick={() => toggleExpanded(stream.name)}
+                        className="flex size-6 items-center justify-center rounded transition-colors hover:bg-muted"
+                        aria-label={
+                          isExpanded ? "Collapse state" : "Expand state"
+                        }
+                      >
+                        {isExpanded ? (
+                          <ChevronDown className="size-4 text-muted-foreground" />
+                        ) : (
+                          <ChevronRight className="size-4 text-muted-foreground" />
+                        )}
+                      </button>
+                    ) : null}
+                  </TableCell>
+                  <TableCell className="font-medium">{stream.name}</TableCell>
+                  <TableCell>
+                    {stream.syncMode === "incremental" ? (
+                      <Badge className="bg-emerald-100 text-emerald-700">
+                        Incremental
+                      </Badge>
+                    ) : (
+                      <Badge variant="secondary">Full Refresh</Badge>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {stream.recordCount?.toLocaleString() ?? "--"}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {stream.cursorField ?? "--"}
+                  </TableCell>
+                  <TableCell className="max-w-48 truncate font-mono text-xs text-muted-foreground">
+                    {stream.cursorValue ?? "--"}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+
+        {/* Expanded state panels render below the table */}
+        {streams
+          .filter(
+            (s) =>
+              expanded.has(s.name) &&
+              s.streamState != null &&
+              Object.keys(s.streamState).length > 0
+          )
+          .map((stream) => (
+            <div
+              key={`state-${stream.name}`}
+              className="border-t bg-muted/30 px-6 py-4"
+            >
+              <p className="mb-2 text-xs font-medium text-muted-foreground">
+                Stream state for{" "}
+                <span className="font-semibold text-foreground">
+                  {stream.name}
+                </span>
+              </p>
+              <pre className="overflow-x-auto rounded-md bg-zinc-950 p-4 font-mono text-xs leading-relaxed text-zinc-300">
+                {JSON.stringify(stream.streamState, null, 2)}
+              </pre>
+            </div>
+          ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/streams/record-count-chart.tsx
+++ b/src/components/streams/record-count-chart.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from "recharts";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import type { StreamSummary } from "@/lib/types/api";
+
+interface RecordCountChartProps {
+  streams: StreamSummary[];
+}
+
+export function RecordCountChart({ streams }: RecordCountChartProps) {
+  const data = useMemo(() => {
+    return streams
+      .filter((s) => s.recordCount != null && s.recordCount > 0)
+      .sort((a, b) => (b.recordCount ?? 0) - (a.recordCount ?? 0))
+      .map((s) => ({
+        name: s.name,
+        records: s.recordCount!,
+      }));
+  }, [streams]);
+
+  const isEmpty = data.length === 0;
+
+  // Dynamic height: 40px per bar, min 200px
+  const chartHeight = Math.max(data.length * 40, 200);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Record Distribution</CardTitle>
+        <CardDescription>
+          Record count per stream (current snapshot)
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isEmpty ? (
+          <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
+            No record count data available
+          </div>
+        ) : (
+          <div style={{ height: Math.min(chartHeight, 480) }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={data}
+                layout="vertical"
+                margin={{ top: 4, right: 24, bottom: 4, left: 8 }}
+              >
+                <XAxis
+                  type="number"
+                  tick={{ fontSize: 12, fill: "var(--color-muted-foreground)" }}
+                  tickLine={false}
+                  axisLine={false}
+                  tickFormatter={(v: number) => v.toLocaleString()}
+                />
+                <YAxis
+                  type="category"
+                  dataKey="name"
+                  width={160}
+                  tick={{ fontSize: 12, fill: "var(--color-muted-foreground)" }}
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: "var(--color-popover)",
+                    borderColor: "var(--color-border)",
+                    borderRadius: "var(--radius-md)",
+                    color: "var(--color-popover-foreground)",
+                    fontSize: 13,
+                  }}
+                  formatter={(value: number | undefined) => [
+                    value != null ? value.toLocaleString() : "--",
+                    "Records",
+                  ]}
+                  cursor={{ fill: "var(--color-muted)", opacity: 0.3 }}
+                />
+                <Bar dataKey="records" radius={[0, 4, 4, 0]} maxBarSize={28}>
+                  {data.map((_, index) => (
+                    <Cell
+                      key={index}
+                      fill={index === 0 ? "#3b82f6" : "#60a5fa"}
+                      opacity={1 - index * 0.04}
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/streams/stream-stats.tsx
+++ b/src/components/streams/stream-stats.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useMemo } from "react";
+import { formatDistanceToNow } from "date-fns";
+import { Layers, Database, Clock } from "lucide-react";
+import {
+  Card,
+  CardContent,
+} from "@/components/ui/card";
+import type { StreamSummary } from "@/lib/types/api";
+
+interface StreamStatsProps {
+  streams: StreamSummary[];
+  lastSyncTimestamp: string | null;
+}
+
+export function StreamStats({ streams, lastSyncTimestamp }: StreamStatsProps) {
+  const { totalRecords, incrementalCount, fullRefreshCount } = useMemo(() => {
+    let total = 0;
+    let inc = 0;
+    let full = 0;
+    for (const s of streams) {
+      if (s.recordCount != null) total += s.recordCount;
+      if (s.syncMode === "incremental") inc++;
+      else full++;
+    }
+    return { totalRecords: total, incrementalCount: inc, fullRefreshCount: full };
+  }, [streams]);
+
+  const freshnessLabel = lastSyncTimestamp
+    ? formatDistanceToNow(new Date(lastSyncTimestamp), { addSuffix: true })
+    : "--";
+
+  const stats = [
+    {
+      label: "Total Streams",
+      value: streams.length.toLocaleString(),
+      icon: Layers,
+    },
+    {
+      label: "Total Records",
+      value: totalRecords.toLocaleString(),
+      icon: Database,
+    },
+    {
+      label: "Data Freshness",
+      value: freshnessLabel,
+      icon: Clock,
+    },
+  ];
+
+  const breakdownParts: string[] = [];
+  if (incrementalCount > 0)
+    breakdownParts.push(`${incrementalCount} incremental`);
+  if (fullRefreshCount > 0)
+    breakdownParts.push(`${fullRefreshCount} full refresh`);
+
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {stats.map((stat) => (
+          <Card key={stat.label}>
+            <CardContent className="flex items-center gap-4 p-4">
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted">
+                <stat.icon className="size-5 text-muted-foreground" />
+              </div>
+              <div className="min-w-0">
+                <p className="text-xs font-medium text-muted-foreground">
+                  {stat.label}
+                </p>
+                <p className="truncate text-lg font-semibold tracking-tight">
+                  {stat.value}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      {breakdownParts.length > 0 && (
+        <p className="text-xs text-muted-foreground">
+          {breakdownParts.join(", ")}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -56,6 +56,8 @@ export interface StreamSummary {
   s3Path: string | null;
   cursorField: string | null;
   cursorValue: string | null;
+  syncMode: "incremental" | "full_refresh";
+  streamState: Record<string, unknown> | null;
 }
 
 export interface SyncStateResponse {


### PR DESCRIPTION
## Summary
- Extends `StreamSummary` type with `syncMode` and `streamState` fields
- Adds `/pipelines/[id]/streams` sub-page with summary stats, record count distribution chart, and enhanced stream table with expandable cursor state
- Adds breadcrumb navigation, "View Streams" link on pipeline detail, and "View all" link on existing StreamTable

## Test plan
- [ ] Navigate to a pipeline with streams — see existing StreamTable with "View all" link
- [ ] Click through to `/pipelines/[id]/streams` — see summary stats, bar chart, enhanced table
- [ ] Verify sync mode badges show correctly (incremental vs full refresh)
- [ ] Expand a stream row — see full cursor state JSON
- [ ] Verify breadcrumbs: Pipelines > [id] > Streams
- [ ] Test with pipeline that has no sync state — empty state displays
- [ ] Test responsive layout at mobile/tablet widths

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)