### PR TITLE
Add user management UI (#30)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -16,6 +16,7 @@ AUTH_SECRET=  # Generate with: openssl rand -hex 32
 COGNITO_CLIENT_ID=
 COGNITO_CLIENT_SECRET=
 COGNITO_ISSUER=  # e.g. https://cognito-idp.us-west-1.amazonaws.com/us-west-1_XXXXXXXX
+COGNITO_USER_POOL_ID=  # e.g. us-west-1_XXXXXXXX
 
 # Alerting (EventBridge → evaluate endpoint auth)
 ALERT_EVALUATE_API_KEY=  # Generate with: openssl rand -hex 32

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.985.0",
         "@aws-sdk/client-cloudwatch-logs": "^3.985.0",
+        "@aws-sdk/client-cognito-identity-provider": "^3.987.0",
         "@aws-sdk/client-dynamodb": "^3.985.0",
         "@aws-sdk/client-scheduler": "^3.985.0",
         "@aws-sdk/client-sfn": "^3.985.0",
@@ -343,6 +344,72 @@
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
         "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider": {
+      "version": "3.987.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.987.0.tgz",
+      "integrity": "sha512-Fp+NyaS78lLGfwPOy4J0B7+GfJny/H9AoqjtrXJeDNXDxuE4m1Tup13HJNKqnf8CpzPfrzQxUMMzNkfRWa020A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.7",
+        "@aws-sdk/credential-provider-node": "^3.972.6",
+        "@aws-sdk/middleware-host-header": "^3.972.3",
+        "@aws-sdk/middleware-logger": "^3.972.3",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+        "@aws-sdk/middleware-user-agent": "^3.972.7",
+        "@aws-sdk/region-config-resolver": "^3.972.3",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.987.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.3",
+        "@aws-sdk/util-user-agent-node": "^3.972.5",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/core": "^3.22.1",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/hash-node": "^4.2.8",
+        "@smithy/invalid-dependency": "^4.2.8",
+        "@smithy/middleware-content-length": "^4.2.8",
+        "@smithy/middleware-endpoint": "^4.4.13",
+        "@smithy/middleware-retry": "^4.4.30",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/node-http-handler": "^4.4.9",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.11.2",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.29",
+        "@smithy/util-defaults-mode-node": "^4.2.32",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.987.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.987.0.tgz",
+      "integrity": "sha512-rZnZwDq7Pn+TnL0nyS6ryAhpqTZtLtHbJaqfxuHlDX3v/bq0M7Ch/V3qF9dZWaGgsJ2H9xn7/vFOxlnL4fBMcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch": "^3.985.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.985.0",
+    "@aws-sdk/client-cognito-identity-provider": "^3.987.0",
     "@aws-sdk/client-dynamodb": "^3.985.0",
     "@aws-sdk/client-scheduler": "^3.985.0",
     "@aws-sdk/client-sfn": "^3.985.0",

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import Link from "next/link";
+import { Users, ShieldAlert } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useUsers } from "@/hooks/use-users";
+import { UsersTable } from "@/components/admin/users-table";
+import { InviteUserDialog } from "@/components/admin/invite-user-dialog";
+
+export default function UserManagementPage() {
+  const { data: session } = useSession();
+  const isAdmin = session?.user?.groups?.includes("Admin") ?? false;
+  const currentUserId = session?.user?.id ?? "";
+
+  const { users, groups, isLoading, error, mutate } = useUsers();
+
+  if (!isAdmin) {
+    return (
+      <div className="mx-auto max-w-7xl p-6">
+        <div className="flex flex-col items-center gap-4 rounded-lg border p-12 text-center">
+          <ShieldAlert className="size-10 text-muted-foreground" />
+          <div>
+            <p className="font-medium text-lg">Admin access required</p>
+            <p className="text-sm text-muted-foreground mt-1">
+              User management is only available to administrators.
+            </p>
+          </div>
+          <Link
+            href="/"
+            className="text-sm text-blue-600 hover:underline mt-2"
+          >
+            Back to pipelines
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Users className="size-5 text-muted-foreground" />
+          <h1 className="text-2xl font-bold tracking-tight">
+            User Management
+          </h1>
+        </div>
+        <InviteUserDialog onSuccess={() => mutate()} />
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-10 w-full rounded-lg" />
+          <Skeleton className="h-16 w-full rounded-lg" />
+          <Skeleton className="h-16 w-full rounded-lg" />
+          <Skeleton className="h-16 w-full rounded-lg" />
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border p-8 text-center">
+          <p className="text-sm text-destructive">
+            Failed to load users. Please try again.
+          </p>
+        </div>
+      ) : (
+        <UsersTable
+          users={users ?? []}
+          groups={groups ?? []}
+          currentUserId={currentUserId}
+          onMutate={() => mutate()}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/api/users/[username]/groups/route.ts
+++ b/src/app/api/users/[username]/groups/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import {
+  getUser,
+  addUserToGroup,
+  removeUserFromGroup,
+  listGroupsForUser,
+} from "@/lib/aws/cognito";
+import { requireAuth, isAdmin, handleAwsError } from "@/lib/api/helpers";
+import type {
+  UpdateUserGroupsRequest,
+  UpdateUserGroupsResponse,
+} from "@/lib/types/api";
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ username: string }> }
+) {
+  try {
+    const authResult = await requireAuth();
+    if (authResult.errorResponse) return authResult.errorResponse;
+    const { session } = authResult;
+
+    if (!isAdmin(session.user.groups)) {
+      return NextResponse.json(
+        { error: "Forbidden", message: "Admin access required" },
+        { status: 403 }
+      );
+    }
+
+    const { username } = await params;
+    const body = (await request.json()) as UpdateUserGroupsRequest;
+
+    // Prevent removing self from Admin
+    if (
+      username === session.user.id &&
+      body.removeGroups?.includes("Admin")
+    ) {
+      return NextResponse.json(
+        {
+          error: "Bad Request",
+          message: "You cannot remove yourself from the Admin group",
+        },
+        { status: 400 }
+      );
+    }
+
+    const user = await getUser(username);
+    if (!user) {
+      return NextResponse.json(
+        { error: "Not Found", message: "User not found" },
+        { status: 404 }
+      );
+    }
+
+    // Process additions
+    if (body.addGroups?.length) {
+      await Promise.all(
+        body.addGroups.map((g) => addUserToGroup(username, g))
+      );
+    }
+
+    // Process removals
+    if (body.removeGroups?.length) {
+      await Promise.all(
+        body.removeGroups.map((g) => removeUserFromGroup(username, g))
+      );
+    }
+
+    const updatedGroups = await listGroupsForUser(username);
+
+    const response: UpdateUserGroupsResponse = {
+      username,
+      groups: updatedGroups,
+    };
+
+    return NextResponse.json(response);
+  } catch (error) {
+    return handleAwsError(error);
+  }
+}

--- a/src/app/api/users/[username]/route.ts
+++ b/src/app/api/users/[username]/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { getUser, deleteUser } from "@/lib/aws/cognito";
+import { requireAuth, isAdmin, handleAwsError } from "@/lib/api/helpers";
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ username: string }> }
+) {
+  try {
+    const authResult = await requireAuth();
+    if (authResult.errorResponse) return authResult.errorResponse;
+    const { session } = authResult;
+
+    if (!isAdmin(session.user.groups)) {
+      return NextResponse.json(
+        { error: "Forbidden", message: "Admin access required" },
+        { status: 403 }
+      );
+    }
+
+    const { username } = await params;
+
+    // Prevent self-deletion
+    if (username === session.user.id) {
+      return NextResponse.json(
+        { error: "Bad Request", message: "You cannot delete your own account" },
+        { status: 400 }
+      );
+    }
+
+    const user = await getUser(username);
+    if (!user) {
+      return NextResponse.json(
+        { error: "Not Found", message: "User not found" },
+        { status: 404 }
+      );
+    }
+
+    await deleteUser(username);
+
+    return NextResponse.json({ message: "User deleted" });
+  } catch (error) {
+    return handleAwsError(error);
+  }
+}

--- a/src/app/api/users/[username]/status/route.ts
+++ b/src/app/api/users/[username]/status/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { getUser, enableUser, disableUser } from "@/lib/aws/cognito";
+import { requireAuth, isAdmin, handleAwsError } from "@/lib/api/helpers";
+import type { UpdateUserStatusRequest } from "@/lib/types/api";
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ username: string }> }
+) {
+  try {
+    const authResult = await requireAuth();
+    if (authResult.errorResponse) return authResult.errorResponse;
+    const { session } = authResult;
+
+    if (!isAdmin(session.user.groups)) {
+      return NextResponse.json(
+        { error: "Forbidden", message: "Admin access required" },
+        { status: 403 }
+      );
+    }
+
+    const { username } = await params;
+    const body = (await request.json()) as UpdateUserStatusRequest;
+
+    // Prevent self-disable
+    if (username === session.user.id && !body.enabled) {
+      return NextResponse.json(
+        {
+          error: "Bad Request",
+          message: "You cannot disable your own account",
+        },
+        { status: 400 }
+      );
+    }
+
+    const user = await getUser(username);
+    if (!user) {
+      return NextResponse.json(
+        { error: "Not Found", message: "User not found" },
+        { status: 404 }
+      );
+    }
+
+    if (body.enabled) {
+      await enableUser(username);
+    } else {
+      await disableUser(username);
+    }
+
+    return NextResponse.json({
+      message: `User ${body.enabled ? "enabled" : "disabled"}`,
+    });
+  } catch (error) {
+    return handleAwsError(error);
+  }
+}

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+import { listUsers, listGroups, createUser } from "@/lib/aws/cognito";
+import { requireAuth, isAdmin, handleAwsError } from "@/lib/api/helpers";
+import type {
+  UsersListResponse,
+  UserResponse,
+  InviteUserRequest,
+  InviteUserResponse,
+} from "@/lib/types/api";
+import type { CognitoUser } from "@/lib/types/users";
+
+const USERNAME_REGEX = /^[a-zA-Z0-9_-]{2,50}$/;
+
+function toUserResponse(user: CognitoUser): UserResponse {
+  return {
+    ...user,
+    isAdmin: user.groups.includes("Admin"),
+    clientGroups: user.groups
+      .filter((g) => g.startsWith("client:"))
+      .map((g) => g.slice("client:".length)),
+  };
+}
+
+export async function GET() {
+  try {
+    const authResult = await requireAuth();
+    if (authResult.errorResponse) return authResult.errorResponse;
+    const { session } = authResult;
+
+    if (!isAdmin(session.user.groups)) {
+      return NextResponse.json(
+        { error: "Forbidden", message: "Admin access required" },
+        { status: 403 }
+      );
+    }
+
+    const [users, groups] = await Promise.all([listUsers(), listGroups()]);
+
+    const body: UsersListResponse = {
+      users: users.map(toUserResponse),
+      groups: groups.map((g) => ({ name: g.name, description: g.description })),
+    };
+
+    return NextResponse.json(body);
+  } catch (error) {
+    return handleAwsError(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const authResult = await requireAuth();
+    if (authResult.errorResponse) return authResult.errorResponse;
+    const { session } = authResult;
+
+    if (!isAdmin(session.user.groups)) {
+      return NextResponse.json(
+        { error: "Forbidden", message: "Admin access required" },
+        { status: 403 }
+      );
+    }
+
+    const body = (await request.json()) as InviteUserRequest;
+
+    // Validate username
+    if (!body.username || !USERNAME_REGEX.test(body.username)) {
+      return NextResponse.json(
+        {
+          error: "Bad Request",
+          message:
+            "Username must be 2-50 characters and contain only letters, numbers, hyphens, and underscores. Do not use an email address.",
+        },
+        { status: 400 }
+      );
+    }
+
+    // Validate email
+    if (!body.email || !body.email.includes("@")) {
+      return NextResponse.json(
+        { error: "Bad Request", message: "A valid email address is required" },
+        { status: 400 }
+      );
+    }
+
+    const user = await createUser(body.username, body.email);
+
+    const response: InviteUserResponse = {
+      username: user.username,
+      email: user.email,
+      temporaryPassword: true,
+    };
+
+    return NextResponse.json(response, { status: 201 });
+  } catch (error) {
+    if (error instanceof Error && error.name === "UsernameExistsException") {
+      return NextResponse.json(
+        { error: "Conflict", message: "A user with this username already exists" },
+        { status: 409 }
+      );
+    }
+    return handleAwsError(error);
+  }
+}

--- a/src/components/admin/delete-user-dialog.tsx
+++ b/src/components/admin/delete-user-dialog.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface DeleteUserDialogProps {
+  username: string | null;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function DeleteUserDialog({
+  username,
+  onClose,
+  onSuccess,
+}: DeleteUserDialogProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDelete = async () => {
+    if (!username) return;
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/users/${encodeURIComponent(username)}`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.message || "Failed to delete user");
+      }
+
+      onClose();
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete user");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={!!username} onOpenChange={(v) => { if (!v) { setError(null); onClose(); } }}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete User</AlertDialogTitle>
+          <AlertDialogDescription>
+            Permanently delete user <strong>{username}</strong>. This action
+            cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {error && (
+          <p className="text-sm text-destructive">{error}</p>
+        )}
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={submitting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={submitting}
+          >
+            {submitting && <Loader2 className="size-4 animate-spin" />}
+            Delete User
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/admin/edit-groups-dialog.tsx
+++ b/src/components/admin/edit-groups-dialog.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Loader2 } from "lucide-react";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import type { UserResponse, GroupResponse } from "@/lib/types/api";
+
+interface EditGroupsDialogProps {
+  user: UserResponse | null;
+  allGroups: GroupResponse[];
+  currentUserId: string;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function EditGroupsDialog({
+  user,
+  allGroups,
+  currentUserId,
+  onClose,
+  onSuccess,
+}: EditGroupsDialogProps) {
+  const [groupState, setGroupState] = useState<Record<string, boolean>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isSelf = user?.username === currentUserId;
+
+  useEffect(() => {
+    if (user) {
+      const state: Record<string, boolean> = {};
+      for (const group of allGroups) {
+        state[group.name] = user.groups.includes(group.name);
+      }
+      setGroupState(state);
+      setError(null);
+    }
+  }, [user, allGroups]);
+
+  const handleSave = async () => {
+    if (!user) return;
+    setSubmitting(true);
+    setError(null);
+
+    const addGroups: string[] = [];
+    const removeGroups: string[] = [];
+
+    for (const group of allGroups) {
+      const wasInGroup = user.groups.includes(group.name);
+      const isNowInGroup = groupState[group.name];
+
+      if (!wasInGroup && isNowInGroup) addGroups.push(group.name);
+      if (wasInGroup && !isNowInGroup) removeGroups.push(group.name);
+    }
+
+    if (addGroups.length === 0 && removeGroups.length === 0) {
+      onClose();
+      return;
+    }
+
+    try {
+      const res = await fetch(`/api/users/${encodeURIComponent(user.username)}/groups`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ addGroups, removeGroups }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.message || "Failed to update groups");
+      }
+
+      onClose();
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update groups");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const adminGroup = allGroups.find((g) => g.name === "Admin");
+  const clientGroups = allGroups.filter((g) => g.name.startsWith("client:"));
+  const otherGroups = allGroups.filter(
+    (g) => g.name !== "Admin" && !g.name.startsWith("client:")
+  );
+
+  return (
+    <AlertDialog open={!!user} onOpenChange={(v) => { if (!v) onClose(); }}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Edit Groups</AlertDialogTitle>
+          <AlertDialogDescription>
+            Manage group membership for <strong>{user?.username}</strong>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="space-y-5 py-2">
+          {adminGroup && (
+            <div className="flex items-center justify-between">
+              <div>
+                <Label className="text-sm font-medium">Admin</Label>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Full access to all pipelines and settings
+                </p>
+              </div>
+              <Switch
+                checked={groupState["Admin"] ?? false}
+                disabled={isSelf}
+                onCheckedChange={(checked) =>
+                  setGroupState((prev) => ({ ...prev, Admin: checked }))
+                }
+              />
+            </div>
+          )}
+
+          {clientGroups.length > 0 && (
+            <>
+              <div className="border-t" />
+              <div className="space-y-3">
+                <p className="text-sm font-medium">Client Groups</p>
+                {clientGroups.map((group) => {
+                  const clientName = group.name.slice("client:".length);
+                  return (
+                    <div
+                      key={group.name}
+                      className="flex items-center justify-between"
+                    >
+                      <Label className="text-sm">{clientName}</Label>
+                      <Switch
+                        checked={groupState[group.name] ?? false}
+                        onCheckedChange={(checked) =>
+                          setGroupState((prev) => ({
+                            ...prev,
+                            [group.name]: checked,
+                          }))
+                        }
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            </>
+          )}
+
+          {otherGroups.length > 0 && (
+            <>
+              <div className="border-t" />
+              <div className="space-y-3">
+                <p className="text-sm font-medium">Other Groups</p>
+                {otherGroups.map((group) => (
+                  <div
+                    key={group.name}
+                    className="flex items-center justify-between"
+                  >
+                    <Label className="text-sm">{group.name}</Label>
+                    <Switch
+                      checked={groupState[group.name] ?? false}
+                      onCheckedChange={(checked) =>
+                        setGroupState((prev) => ({
+                          ...prev,
+                          [group.name]: checked,
+                        }))
+                      }
+                    />
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+
+          {isSelf && (
+            <p className="text-xs text-muted-foreground">
+              You cannot remove yourself from the Admin group.
+            </p>
+          )}
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={submitting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={handleSave} disabled={submitting}>
+            {submitting && <Loader2 className="size-4 animate-spin" />}
+            Save Changes
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/admin/invite-user-dialog.tsx
+++ b/src/components/admin/invite-user-dialog.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, UserPlus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+
+interface InviteUserDialogProps {
+  onSuccess: () => void;
+}
+
+export function InviteUserDialog({ onSuccess }: InviteUserDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setUsername("");
+    setEmail("");
+    setError(null);
+    setSubmitting(false);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/users", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username: username.trim(), email: email.trim() }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.message || "Failed to invite user");
+      }
+
+      reset();
+      setOpen(false);
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to invite user");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={(v) => { setOpen(v); if (!v) reset(); }}>
+      <AlertDialogTrigger asChild>
+        <Button>
+          <UserPlus className="size-4" />
+          Invite User
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <form onSubmit={handleSubmit}>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Invite User</AlertDialogTitle>
+            <AlertDialogDescription>
+              Create a new user account. They will receive a temporary password
+              via email.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="invite-username">Username</Label>
+              <Input
+                id="invite-username"
+                placeholder="e.g. jason"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                required
+                autoFocus
+              />
+              <p className="text-xs text-muted-foreground">
+                Short name — not an email address. Letters, numbers, hyphens,
+                and underscores only.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="invite-email">Email</Label>
+              <Input
+                id="invite-email"
+                type="email"
+                placeholder="jason@example.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+            </div>
+            {error && (
+              <p className="text-sm text-destructive">{error}</p>
+            )}
+          </div>
+
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={submitting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              type="submit"
+              disabled={submitting || !username.trim() || !email.trim()}
+            >
+              {submitting && <Loader2 className="size-4 animate-spin" />}
+              Send Invite
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </form>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/admin/users-table.tsx
+++ b/src/components/admin/users-table.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useState } from "react";
+import { format, parseISO } from "date-fns";
+import { MoreHorizontal, Shield, UserCog, UserX, UserCheck } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { EditGroupsDialog } from "@/components/admin/edit-groups-dialog";
+import { DeleteUserDialog } from "@/components/admin/delete-user-dialog";
+import type { UserResponse, GroupResponse } from "@/lib/types/api";
+
+interface UsersTableProps {
+  users: UserResponse[];
+  groups: GroupResponse[];
+  currentUserId: string;
+  onMutate: () => void;
+}
+
+function StatusBadge({ user }: { user: UserResponse }) {
+  if (!user.enabled) {
+    return (
+      <Badge variant="destructive" className="text-xs">
+        Disabled
+      </Badge>
+    );
+  }
+
+  if (user.status === "FORCE_CHANGE_PASSWORD") {
+    return (
+      <Badge variant="secondary" className="text-xs border-amber-300 bg-amber-50 text-amber-700">
+        Pending
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="secondary" className="text-xs border-green-300 bg-green-50 text-green-700">
+      Active
+    </Badge>
+  );
+}
+
+export function UsersTable({ users, groups, currentUserId, onMutate }: UsersTableProps) {
+  const [editGroupsUser, setEditGroupsUser] = useState<UserResponse | null>(null);
+  const [deleteUsername, setDeleteUsername] = useState<string | null>(null);
+  const [togglingStatus, setTogglingStatus] = useState<string | null>(null);
+
+  const handleToggleStatus = async (user: UserResponse) => {
+    setTogglingStatus(user.username);
+
+    try {
+      const res = await fetch(
+        `/api/users/${encodeURIComponent(user.username)}/status`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ enabled: !user.enabled }),
+        }
+      );
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.message || "Failed to update status");
+      }
+
+      onMutate();
+    } catch (err) {
+      console.error("Failed to toggle user status:", err);
+    } finally {
+      setTogglingStatus(null);
+    }
+  };
+
+  return (
+    <>
+      <div className="rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Username</TableHead>
+              <TableHead>Email</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Groups</TableHead>
+              <TableHead className="text-right">Created</TableHead>
+              <TableHead className="w-12" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {users.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
+                  No users found
+                </TableCell>
+              </TableRow>
+            ) : (
+              users.map((user) => {
+                const isSelf = user.username === currentUserId;
+
+                return (
+                  <TableRow key={user.username}>
+                    <TableCell className="font-medium">
+                      {user.username}
+                      {isSelf && (
+                        <span className="ml-1.5 text-xs text-muted-foreground">(you)</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {user.email}
+                    </TableCell>
+                    <TableCell>
+                      <StatusBadge user={user} />
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap gap-1">
+                        {user.isAdmin && (
+                          <Badge className="text-xs gap-1">
+                            <Shield className="size-3" />
+                            Admin
+                          </Badge>
+                        )}
+                        {user.clientGroups.map((client) => (
+                          <Badge key={client} variant="outline" className="text-xs">
+                            {client}
+                          </Badge>
+                        ))}
+                        {!user.isAdmin && user.clientGroups.length === 0 && (
+                          <span className="text-xs text-muted-foreground">None</span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right text-sm text-muted-foreground">
+                      {user.createdAt
+                        ? format(parseISO(user.createdAt), "MMM d, yyyy")
+                        : "—"}
+                    </TableCell>
+                    <TableCell>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="size-8"
+                          >
+                            <MoreHorizontal className="size-4" />
+                            <span className="sr-only">Actions</span>
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            onClick={() => setEditGroupsUser(user)}
+                          >
+                            <UserCog className="size-4" />
+                            Edit Groups
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() => handleToggleStatus(user)}
+                            disabled={isSelf || togglingStatus === user.username}
+                          >
+                            {user.enabled ? (
+                              <>
+                                <UserX className="size-4" />
+                                Disable
+                              </>
+                            ) : (
+                              <>
+                                <UserCheck className="size-4" />
+                                Enable
+                              </>
+                            )}
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            className="text-destructive focus:text-destructive"
+                            onClick={() => setDeleteUsername(user.username)}
+                            disabled={isSelf}
+                          >
+                            <UserX className="size-4" />
+                            Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <EditGroupsDialog
+        user={editGroupsUser}
+        allGroups={groups}
+        currentUserId={currentUserId}
+        onClose={() => setEditGroupsUser(null)}
+        onSuccess={onMutate}
+      />
+
+      <DeleteUserDialog
+        username={deleteUsername}
+        onClose={() => setDeleteUsername(null)}
+        onSuccess={onMutate}
+      />
+    </>
+  );
+}

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -2,13 +2,15 @@
 
 import { usePathname } from "next/navigation";
 import Link from "next/link";
-import { GitBranch, BarChart3 } from "lucide-react";
+import { useSession } from "next-auth/react";
+import { GitBranch, BarChart3, Users } from "lucide-react";
 import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
+  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
@@ -29,8 +31,18 @@ const navItems = [
   },
 ];
 
+const adminNavItems = [
+  {
+    title: "Users",
+    url: "/admin/users",
+    icon: Users,
+  },
+];
+
 export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
   const pathname = usePathname();
+  const { data: session } = useSession();
+  const isAdmin = session?.user?.groups?.includes("Admin") ?? false;
 
   return (
     <Sidebar collapsible="icon" {...props}>
@@ -81,6 +93,35 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
+
+        {isAdmin && (
+          <SidebarGroup>
+            <SidebarGroupLabel>Admin</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {adminNavItems.map((item) => {
+                  const isActive =
+                    pathname === item.url || pathname.startsWith(item.url + "/");
+
+                  return (
+                    <SidebarMenuItem key={item.title}>
+                      <SidebarMenuButton
+                        asChild
+                        isActive={isActive}
+                        tooltip={item.title}
+                      >
+                        <Link href={item.url}>
+                          <item.icon />
+                          <span>{item.title}</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  );
+                })}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        )}
       </SidebarContent>
       <SidebarFooter>
         <SidebarUserNav />

--- a/src/components/layout/breadcrumb-nav.tsx
+++ b/src/components/layout/breadcrumb-nav.tsx
@@ -14,6 +14,19 @@ import {
 export function BreadcrumbNav() {
   const pathname = usePathname();
 
+  // /admin/users → User Management
+  if (pathname === "/admin/users") {
+    return (
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbPage>User Management</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+    );
+  }
+
   // /pipelines/[id]/executions/[executionId] → Pipelines > id > Executions > executionId
   const executionDetailMatch = pathname.match(
     /^\/pipelines\/([^/]+)\/executions\/([^/]+)$/

--- a/src/hooks/use-users.ts
+++ b/src/hooks/use-users.ts
@@ -1,0 +1,19 @@
+import useSWR from "swr";
+import type { UsersListResponse } from "@/lib/types/api";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export function useUsers() {
+  const { data, error, isLoading, mutate } =
+    useSWR<UsersListResponse>("/api/users", fetcher, {
+      refreshInterval: 0,
+    });
+
+  return {
+    users: data?.users,
+    groups: data?.groups,
+    isLoading,
+    error,
+    mutate,
+  };
+}

--- a/src/lib/aws/client.ts
+++ b/src/lib/aws/client.ts
@@ -4,6 +4,7 @@ import { SFNClient } from "@aws-sdk/client-sfn";
 import { CloudWatchClient } from "@aws-sdk/client-cloudwatch";
 import { CloudWatchLogsClient } from "@aws-sdk/client-cloudwatch-logs";
 import { SNSClient } from "@aws-sdk/client-sns";
+import { CognitoIdentityProviderClient } from "@aws-sdk/client-cognito-identity-provider";
 
 const awsConfig = {
   region: process.env.OBLIK_AWS_REGION || process.env.AWS_REGION,
@@ -21,6 +22,7 @@ let sfnClient: SFNClient | null = null;
 let cloudWatchClient: CloudWatchClient | null = null;
 let cloudWatchLogsClient: CloudWatchLogsClient | null = null;
 let snsClient: SNSClient | null = null;
+let cognitoClient: CognitoIdentityProviderClient | null = null;
 
 export function getDynamoDBClient(): DynamoDBDocumentClient {
   if (!dynamoDBClient) {
@@ -58,4 +60,11 @@ export function getSNSClient(): SNSClient {
     snsClient = new SNSClient(awsConfig);
   }
   return snsClient;
+}
+
+export function getCognitoClient(): CognitoIdentityProviderClient {
+  if (!cognitoClient) {
+    cognitoClient = new CognitoIdentityProviderClient(awsConfig);
+  }
+  return cognitoClient;
 }

--- a/src/lib/aws/cognito.ts
+++ b/src/lib/aws/cognito.ts
@@ -1,0 +1,280 @@
+import {
+  ListUsersCommand,
+  ListGroupsCommand,
+  AdminGetUserCommand,
+  AdminCreateUserCommand,
+  AdminAddUserToGroupCommand,
+  AdminRemoveUserFromGroupCommand,
+  AdminDisableUserCommand,
+  AdminEnableUserCommand,
+  AdminDeleteUserCommand,
+  AdminListGroupsForUserCommand,
+  type AttributeType,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { getCognitoClient } from "./client";
+import type { CognitoUser, CognitoGroup } from "@/lib/types/users";
+import { AwsServiceError } from "@/lib/types/pipeline";
+
+const USER_POOL_ID = process.env.COGNITO_USER_POOL_ID!;
+
+function getAttr(
+  attrs: AttributeType[] | undefined,
+  name: string
+): string | undefined {
+  return attrs?.find((a) => a.Name === name)?.Value;
+}
+
+export async function listGroupsForUser(username: string): Promise<string[]> {
+  const client = getCognitoClient();
+
+  try {
+    const result = await client.send(
+      new AdminListGroupsForUserCommand({
+        UserPoolId: USER_POOL_ID,
+        Username: username,
+      })
+    );
+
+    return (result.Groups ?? []).map((g) => g.GroupName!);
+  } catch (error) {
+    throw new AwsServiceError("Cognito", "AdminListGroupsForUser", error);
+  }
+}
+
+export async function listUsers(): Promise<CognitoUser[]> {
+  const client = getCognitoClient();
+  const allUsers: CognitoUser[] = [];
+  let paginationToken: string | undefined;
+
+  try {
+    do {
+      const result = await client.send(
+        new ListUsersCommand({
+          UserPoolId: USER_POOL_ID,
+          Limit: 60,
+          PaginationToken: paginationToken,
+        })
+      );
+
+      const users = (result.Users ?? []).map((u) => ({
+        username: u.Username!,
+        email: getAttr(u.Attributes, "email") ?? "",
+        status: u.UserStatus ?? "UNKNOWN",
+        enabled: u.Enabled ?? false,
+        createdAt: u.UserCreateDate?.toISOString() ?? "",
+        lastModifiedAt: u.UserLastModifiedDate?.toISOString() ?? "",
+        groups: [] as string[],
+      }));
+
+      allUsers.push(...users);
+      paginationToken = result.PaginationToken;
+    } while (paginationToken);
+  } catch (error) {
+    throw new AwsServiceError("Cognito", "ListUsers", error);
+  }
+
+  // Fetch groups for each user (batched concurrency of 10)
+  const batchSize = 10;
+  for (let i = 0; i < allUsers.length; i += batchSize) {
+    const batch = allUsers.slice(i, i + batchSize);
+    const groupResults = await Promise.all(
+      batch.map((u) => listGroupsForUser(u.username))
+    );
+    batch.forEach((u, idx) => {
+      u.groups = groupResults[idx];
+    });
+  }
+
+  return allUsers;
+}
+
+export async function listGroups(): Promise<CognitoGroup[]> {
+  const client = getCognitoClient();
+  const allGroups: CognitoGroup[] = [];
+  let nextToken: string | undefined;
+
+  try {
+    do {
+      const result = await client.send(
+        new ListGroupsCommand({
+          UserPoolId: USER_POOL_ID,
+          Limit: 60,
+          NextToken: nextToken,
+        })
+      );
+
+      const groups = (result.Groups ?? []).map((g) => ({
+        name: g.GroupName!,
+        description: g.Description ?? null,
+      }));
+
+      allGroups.push(...groups);
+      nextToken = result.NextToken;
+    } while (nextToken);
+  } catch (error) {
+    throw new AwsServiceError("Cognito", "ListGroups", error);
+  }
+
+  return allGroups;
+}
+
+export async function getUser(
+  username: string
+): Promise<CognitoUser | null> {
+  const client = getCognitoClient();
+
+  try {
+    const result = await client.send(
+      new AdminGetUserCommand({
+        UserPoolId: USER_POOL_ID,
+        Username: username,
+      })
+    );
+
+    const groups = await listGroupsForUser(username);
+
+    return {
+      username: result.Username!,
+      email: getAttr(result.UserAttributes, "email") ?? "",
+      status: result.UserStatus ?? "UNKNOWN",
+      enabled: result.Enabled ?? false,
+      createdAt: result.UserCreateDate?.toISOString() ?? "",
+      lastModifiedAt: result.UserLastModifiedDate?.toISOString() ?? "",
+      groups,
+    };
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.name === "UserNotFoundException"
+    ) {
+      return null;
+    }
+    throw new AwsServiceError("Cognito", "AdminGetUser", error);
+  }
+}
+
+export async function createUser(
+  username: string,
+  email: string
+): Promise<CognitoUser> {
+  const client = getCognitoClient();
+
+  try {
+    const result = await client.send(
+      new AdminCreateUserCommand({
+        UserPoolId: USER_POOL_ID,
+        Username: username,
+        UserAttributes: [
+          { Name: "email", Value: email },
+          { Name: "email_verified", Value: "true" },
+        ],
+        DesiredDeliveryMediums: ["EMAIL"],
+      })
+    );
+
+    const user = result.User!;
+
+    return {
+      username: user.Username!,
+      email: getAttr(user.Attributes, "email") ?? email,
+      status: user.UserStatus ?? "FORCE_CHANGE_PASSWORD",
+      enabled: user.Enabled ?? true,
+      createdAt: user.UserCreateDate?.toISOString() ?? new Date().toISOString(),
+      lastModifiedAt:
+        user.UserLastModifiedDate?.toISOString() ?? new Date().toISOString(),
+      groups: [],
+    };
+  } catch (error) {
+    // Let UsernameExistsException bubble up so API can return 409
+    if (
+      error instanceof Error &&
+      error.name === "UsernameExistsException"
+    ) {
+      throw error;
+    }
+    throw new AwsServiceError("Cognito", "AdminCreateUser", error);
+  }
+}
+
+export async function addUserToGroup(
+  username: string,
+  groupName: string
+): Promise<void> {
+  const client = getCognitoClient();
+
+  try {
+    await client.send(
+      new AdminAddUserToGroupCommand({
+        UserPoolId: USER_POOL_ID,
+        Username: username,
+        GroupName: groupName,
+      })
+    );
+  } catch (error) {
+    throw new AwsServiceError("Cognito", "AdminAddUserToGroup", error);
+  }
+}
+
+export async function removeUserFromGroup(
+  username: string,
+  groupName: string
+): Promise<void> {
+  const client = getCognitoClient();
+
+  try {
+    await client.send(
+      new AdminRemoveUserFromGroupCommand({
+        UserPoolId: USER_POOL_ID,
+        Username: username,
+        GroupName: groupName,
+      })
+    );
+  } catch (error) {
+    throw new AwsServiceError("Cognito", "AdminRemoveUserFromGroup", error);
+  }
+}
+
+export async function disableUser(username: string): Promise<void> {
+  const client = getCognitoClient();
+
+  try {
+    await client.send(
+      new AdminDisableUserCommand({
+        UserPoolId: USER_POOL_ID,
+        Username: username,
+      })
+    );
+  } catch (error) {
+    throw new AwsServiceError("Cognito", "AdminDisableUser", error);
+  }
+}
+
+export async function enableUser(username: string): Promise<void> {
+  const client = getCognitoClient();
+
+  try {
+    await client.send(
+      new AdminEnableUserCommand({
+        UserPoolId: USER_POOL_ID,
+        Username: username,
+      })
+    );
+  } catch (error) {
+    throw new AwsServiceError("Cognito", "AdminEnableUser", error);
+  }
+}
+
+export async function deleteUser(username: string): Promise<void> {
+  const client = getCognitoClient();
+
+  try {
+    await client.send(
+      new AdminDeleteUserCommand({
+        UserPoolId: USER_POOL_ID,
+        Username: username,
+      })
+    );
+  } catch (error) {
+    throw new AwsServiceError("Cognito", "AdminDeleteUser", error);
+  }
+}

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -249,6 +249,55 @@ export interface AnalyticsSummaryResponse {
   };
 }
 
+// ── User management endpoints ──
+
+export interface UserResponse {
+  username: string;
+  email: string;
+  status: string;
+  enabled: boolean;
+  createdAt: string;
+  lastModifiedAt: string;
+  groups: string[];
+  isAdmin: boolean;
+  clientGroups: string[];
+}
+
+export interface GroupResponse {
+  name: string;
+  description: string | null;
+}
+
+export interface UsersListResponse {
+  users: UserResponse[];
+  groups: GroupResponse[];
+}
+
+export interface InviteUserRequest {
+  username: string;
+  email: string;
+}
+
+export interface InviteUserResponse {
+  username: string;
+  email: string;
+  temporaryPassword: boolean;
+}
+
+export interface UpdateUserGroupsRequest {
+  addGroups?: string[];
+  removeGroups?: string[];
+}
+
+export interface UpdateUserGroupsResponse {
+  username: string;
+  groups: string[];
+}
+
+export interface UpdateUserStatusRequest {
+  enabled: boolean;
+}
+
 // ── Pipeline detail endpoint ──
 
 export interface PipelineDetailResponse {

--- a/src/lib/types/users.ts
+++ b/src/lib/types/users.ts
@@ -1,0 +1,14 @@
+export interface CognitoUser {
+  username: string;
+  email: string;
+  status: string;
+  enabled: boolean;
+  createdAt: string; // ISO 8601
+  lastModifiedAt: string; // ISO 8601
+  groups: string[];
+}
+
+export interface CognitoGroup {
+  name: string;
+  description: string | null;
+}


### PR DESCRIPTION
## Summary
- Adds admin-only `/admin/users` page for managing Cognito user pool users
- Implements Cognito SDK integration (`@aws-sdk/client-cognito-identity-provider`) with full CRUD: list users, invite (with temp password via email), manage group membership, enable/disable, and delete
- Admin-only API routes at `/api/users` with self-protection guards (cannot delete/disable yourself or remove yourself from Admin)
- Sidebar gains an "Admin" section with "Users" link, visible only to Admin group members

## New files
- `src/lib/aws/cognito.ts` — Cognito query module (10 functions)
- `src/app/api/users/` — 4 route files (list+invite, delete, groups, status)
- `src/app/admin/users/page.tsx` — User management page
- `src/components/admin/` — UsersTable, InviteUserDialog, EditGroupsDialog, DeleteUserDialog
- `src/hooks/use-users.ts` — SWR hook
- `src/lib/types/users.ts` — Internal Cognito types

## Test plan
- [ ] Add `COGNITO_USER_POOL_ID=us-west-1_RUDVvtNIm` to `.env.local`
- [ ] Verify `/admin/users` loads users table with correct status/group badges
- [ ] Invite a test user — verify temp password email is received
- [ ] Edit groups — toggle Admin and client groups, verify persistence
- [ ] Disable/enable a user — verify status badge updates
- [ ] Delete a test user — verify confirmation dialog and removal
- [ ] Verify sidebar "Users" link only appears for admin users
- [ ] Verify non-admin users see "Admin access required" gate
- [ ] Verify self-protection: cannot disable/delete/de-admin yourself
- [ ] Set `COGNITO_USER_POOL_ID` on Amplify (app-level env var, full replace)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)