### PR TITLE
Group pipelines by client and show next run time

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -96,10 +96,28 @@ export default function Home() {
           </p>
         </div>
       ) : pipelines ? (
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {pipelines.map((pipeline) => (
-            <PipelineCard key={pipeline.pipelineId} pipeline={pipeline} />
-          ))}
+        <div className="space-y-8">
+          {Object.entries(
+            pipelines.reduce<Record<string, typeof pipelines>>((groups, p) => {
+              (groups[p.clientName] ??= []).push(p);
+              return groups;
+            }, {})
+          )
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([clientName, group]) => (
+              <section key={clientName}>
+                <h2 className="mb-3 text-lg font-semibold tracking-tight text-foreground">
+                  {clientName}
+                </h2>
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+                  {group
+                    .sort((a, b) => a.connectorType.localeCompare(b.connectorType))
+                    .map((pipeline) => (
+                      <PipelineCard key={pipeline.pipelineId} pipeline={pipeline} />
+                    ))}
+                </div>
+              </section>
+            ))}
         </div>
       ) : null}
     </div>

--- a/src/components/dashboard/pipeline-card.tsx
+++ b/src/components/dashboard/pipeline-card.tsx
@@ -7,8 +7,6 @@ import {
   FileSpreadsheet,
   Globe,
   HardDrive,
-  Power,
-  PowerOff,
 } from "lucide-react";
 import {
   Card,
@@ -49,9 +47,9 @@ export function PipelineCard({ pipeline }: PipelineCardProps) {
           <div>
             <CardTitle className="flex items-center gap-2">
               <ConnectorIcon connectorType={pipeline.connectorType} className="size-4 text-muted-foreground" />
-              {pipeline.clientName}
+              {pipeline.connectorType}
             </CardTitle>
-            <CardDescription>{pipeline.connectorType}</CardDescription>
+            <CardDescription>{pipeline.environment}</CardDescription>
           </div>
           <CardAction>
             <StatusBadge status={pipeline.status} />
@@ -96,19 +94,13 @@ export function PipelineCard({ pipeline }: PipelineCardProps) {
               </dd>
             </div>
             <div>
-              <dt className="text-muted-foreground">Status</dt>
-              <dd className="flex items-center gap-1.5 font-medium">
-                {pipeline.enabled ? (
-                  <>
-                    <Power className="size-3.5 text-emerald-600" />
-                    Enabled
-                  </>
-                ) : (
-                  <>
-                    <PowerOff className="size-3.5 text-zinc-400" />
-                    Disabled
-                  </>
-                )}
+              <dt className="text-muted-foreground">Next Run</dt>
+              <dd className="font-medium">
+                {pipeline.nextRunAt
+                  ? formatDistanceToNow(new Date(pipeline.nextRunAt), {
+                      addSuffix: true,
+                    })
+                  : "—"}
               </dd>
             </div>
           </dl>

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -27,6 +27,7 @@ export interface PipelineOverview {
   lastSync: LastSyncSummary | null;
   recentSuccessRate: number;
   scheduleExpression: string;
+  nextRunAt: string | null;
 }
 
 export interface PipelinesListResponse {


### PR DESCRIPTION
## Summary
- **#42** — Group pipeline cards by client name with alphabetical sorting and section headers
- **#41** — Replace enabled/disabled status field with computed "Next Run" time on each pipeline card
- Pipeline card title updated to show connector type (client name now in group header)

## Changes
- `src/lib/types/api.ts` — Add `nextRunAt: string | null` to `PipelineOverview`
- `src/app/api/pipelines/route.ts` — Compute next run from last sync + schedule interval
- `src/app/page.tsx` — Group pipelines by client, sort groups and pipelines alphabetically
- `src/components/dashboard/pipeline-card.tsx` — Show "Next Run" field, display connector type as title

## Test plan
- [ ] Verify pipelines are grouped by client name with section headers
- [ ] Verify groups and pipelines within groups are sorted alphabetically
- [ ] Verify "Next Run" shows relative time for enabled pipelines with upcoming runs
- [ ] Verify "Next Run" shows "—" for disabled pipelines, running pipelines, or past-due runs
- [ ] Verify card title shows connector type and subtitle shows environment

Closes #41, closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)