### PR TITLE
Group Flooret pipelines under a single section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,18 @@ import { usePipelines } from "@/hooks/use-pipelines";
 import { QuickStats, QuickStatsSkeleton } from "@/components/dashboard/quick-stats";
 import { PipelineCard, PipelineCardSkeleton } from "@/components/dashboard/pipeline-card";
 
+/** Maps client_name values to display group names. Unmapped names pass through as-is. */
+const CLIENT_GROUPS: Record<string, string> = {
+  flooret: "Flooret",
+  "flooret-commercial": "Flooret",
+  "flooret-d2c": "Flooret",
+  wavv: "Wavv",
+};
+
+function getClientGroup(clientName: string): string {
+  return CLIENT_GROUPS[clientName] ?? clientName;
+}
+
 export default function Home() {
   const lastUpdatedRef = useRef<Date | null>(null);
   const [lastUpdatedText, setLastUpdatedText] = useState<string | null>(null);
@@ -99,7 +111,8 @@ export default function Home() {
         <div className="space-y-8">
           {Object.entries(
             pipelines.reduce<Record<string, typeof pipelines>>((groups, p) => {
-              (groups[p.clientName] ??= []).push(p);
+              const group = getClientGroup(p.clientName);
+              (groups[group] ??= []).push(p);
               return groups;
             }, {})
           )


### PR DESCRIPTION
## Summary
- Add a client group mapping so `flooret`, `flooret-commercial`, and `flooret-d2c` all appear under one "Flooret" heading on the dashboard
- Unmapped client names pass through as-is, so new clients work without code changes

## Test plan
- [ ] Verify all three Flooret pipelines appear under a single "Flooret" section
- [ ] Verify Wavv pipelines still appear under their own section

🤖 Generated with [Claude Code](https://claude.com/claude-code)