### PR TITLE
feat(api): filter SFN executions by job name

### DIFF
--- a/src/app/api/transformations/[jobId]/executions/route.ts
+++ b/src/app/api/transformations/[jobId]/executions/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getTransformationJob } from "@/lib/aws/transformation-db";
-import { listExecutions } from "@/lib/aws/stepfunctions";
+import { listExecutionsForJob } from "@/lib/aws/stepfunctions";
 import {
   requireAuth,
   getClientFilter,
@@ -60,12 +60,16 @@ export async function GET(
     const statusFilter =
       statusParam && VALID_STATUSES.has(statusParam) ? statusParam : undefined;
 
-    // 6. Fetch executions
-    const result = await listExecutions(job.state_machine_arn, {
-      statusFilter,
-      maxResults: 20,
-      nextToken: nextTokenParam,
-    });
+    // 6. Fetch executions filtered by job name
+    const result = await listExecutionsForJob(
+      job.state_machine_arn,
+      job.job_name,
+      {
+        statusFilter,
+        maxResults: 20,
+        nextToken: nextTokenParam,
+      }
+    );
 
     // 7. Build response
     const body: ExecutionsListResponse = {

--- a/src/app/api/transformations/[jobId]/route.ts
+++ b/src/app/api/transformations/[jobId]/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { getTransformationJob } from "@/lib/aws/transformation-db";
 import {
-  isCurrentlyRunning,
-  listExecutions,
+  isJobCurrentlyRunning,
+  listExecutionsForJob,
 } from "@/lib/aws/stepfunctions";
 import {
   requireAuth,
@@ -52,8 +52,10 @@ export async function GET(
 
     // 5. Parallel enrichment
     const [runningResult, execResult] = await Promise.allSettled([
-      isCurrentlyRunning(job.state_machine_arn),
-      listExecutions(job.state_machine_arn, { maxResults: 10 }),
+      isJobCurrentlyRunning(job.state_machine_arn, job.job_name),
+      listExecutionsForJob(job.state_machine_arn, job.job_name, {
+        maxResults: 10,
+      }),
     ]);
 
     const running =

--- a/src/app/api/transformations/route.ts
+++ b/src/app/api/transformations/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { listTransformationJobs } from "@/lib/aws/transformation-db";
 import {
-  isCurrentlyRunning,
   listExecutions,
+  groupExecutionsByJob,
 } from "@/lib/aws/stepfunctions";
 import {
   requireAuth,
@@ -32,41 +32,59 @@ export async function GET() {
     const allowedClients = getClientFilter(session.user.groups);
     const jobs = filterTransformationJobsByClient(allJobs, allowedClients);
 
-    // 4. Group jobs by SFN ARN to deduplicate queries
-    const sfnArnMap = new Map<
-      string,
-      { running: boolean; executions: Awaited<ReturnType<typeof listExecutions>>["executions"] }
-    >();
-
+    // 4. Fetch executions per unique SFN ARN, then group by job name
     const uniqueArns = [...new Set(jobs.map((j) => j.state_machine_arn))];
+
+    // Fetch executions for each ARN (including RUNNING for status detection)
+    const arnExecutions = new Map<
+      string,
+      { all: Awaited<ReturnType<typeof listExecutions>>["executions"]; running: Awaited<ReturnType<typeof listExecutions>>["executions"] }
+    >();
 
     await Promise.all(
       uniqueArns.map(async (arn) => {
         const results = await Promise.allSettled([
-          isCurrentlyRunning(arn),
-          listExecutions(arn, { maxResults: 10 }),
+          listExecutions(arn, { maxResults: 20 }),
+          listExecutions(arn, { statusFilter: "RUNNING", maxResults: 10 }),
         ]);
 
-        const running =
-          results[0].status === "fulfilled" ? results[0].value : false;
-        const execResult =
-          results[1].status === "fulfilled" ? results[1].value : null;
+        const arnAllExecs =
+          results[0].status === "fulfilled"
+            ? results[0].value.executions
+            : [];
+        const arnRunningExecs =
+          results[1].status === "fulfilled"
+            ? results[1].value.executions
+            : [];
 
-        sfnArnMap.set(arn, {
-          running,
-          executions: execResult?.executions ?? [],
-        });
+        arnExecutions.set(arn, { all: arnAllExecs, running: arnRunningExecs });
       })
     );
 
-    // 5. Build overview for each job
-    const enriched: TransformationJobOverview[] = jobs.map((job) => {
-      const sfnData = sfnArnMap.get(job.state_machine_arn) ?? {
-        running: false,
-        executions: [],
-      };
+    // Collect all executions and group by job name via input inspection
+    const allExecs = [...arnExecutions.values()].flatMap((v) => v.all);
+    const allRunning = new Set(
+      [...arnExecutions.values()]
+        .flatMap((v) => v.running)
+        .map((e) => e.executionArn)
+    );
 
-      const latest = sfnData.executions[0];
+    const execsByJob = await groupExecutionsByJob(allExecs);
+
+    // Derive running status per job from the grouped results
+    const runningByJob = new Map<string, boolean>();
+    for (const [jobName, execs] of execsByJob) {
+      runningByJob.set(
+        jobName,
+        execs.some((e) => allRunning.has(e.executionArn))
+      );
+    }
+
+    // 5. Build overview for each job using its own executions
+    const enriched: TransformationJobOverview[] = jobs.map((job) => {
+      const jobExecs = execsByJob.get(job.job_name) ?? [];
+      const isRunning = runningByJob.get(job.job_name) ?? false;
+      const latest = jobExecs[0];
 
       return {
         jobId: job.job_id,
@@ -75,12 +93,12 @@ export async function GET() {
         triggerType: job.trigger_type,
         scheduleExpression: job.schedule_expression,
         dbtCommands: job.dbt_commands,
-        status: computeTransformationStatus(sfnData.running, latest),
-        isCurrentlyRunning: sfnData.running,
+        status: computeTransformationStatus(isRunning, latest),
+        isCurrentlyRunning: isRunning,
         lastRun: buildLastSync(
-          sfnData.executions.find((e) => e.status !== "RUNNING")
+          jobExecs.find((e) => e.status !== "RUNNING")
         ),
-        recentSuccessRate: computeSuccessRate(sfnData.executions),
+        recentSuccessRate: computeSuccessRate(jobExecs),
       };
     });
 

--- a/src/lib/aws/stepfunctions.ts
+++ b/src/lib/aws/stepfunctions.ts
@@ -201,3 +201,136 @@ export async function getLatestExecution(
   const result = await listExecutions(stateMachineArn, { maxResults: 1 });
   return result.executions[0] ?? null;
 }
+
+// ── Job-filtered execution helpers (transformation pipelines) ──
+
+/**
+ * Extracts the job name from a Step Functions execution input payload.
+ * Returns null if input is missing or doesn't contain a recognizable job.
+ */
+function extractJobName(input?: string): string | null {
+  if (!input) return null;
+  try {
+    const parsed = JSON.parse(input);
+    const jobs = parsed.jobs;
+    if (Array.isArray(jobs) && jobs.length > 0) {
+      return jobs[0].job_name ?? null;
+    }
+  } catch {
+    // Malformed input — skip
+  }
+  return null;
+}
+
+/**
+ * Lists executions for a specific job by filtering on the execution input payload.
+ * Fetches candidate executions, describes each to get the input, and returns
+ * only those whose `jobs[].job_name` matches the target.
+ */
+export async function listExecutionsForJob(
+  stateMachineArn: string,
+  jobName: string,
+  opts?: ListExecutionsOptions
+): Promise<ListExecutionsResult> {
+  const desiredCount = opts?.maxResults ?? 20;
+  // Fetch more candidates than needed since some won't match
+  const candidateCount = Math.min(desiredCount * 3, 100);
+
+  const candidates = await listExecutions(stateMachineArn, {
+    statusFilter: opts?.statusFilter,
+    maxResults: candidateCount,
+    nextToken: opts?.nextToken,
+  });
+
+  // Describe each execution in parallel to get the input payload
+  const described = await describeExecutionsBatch(
+    candidates.executions.map((e) => e.executionArn)
+  );
+
+  // Build a lookup of executionArn -> input
+  const inputByArn = new Map<string, string | undefined>();
+  for (const detail of described) {
+    inputByArn.set(detail.executionArn, detail.input);
+  }
+
+  // Filter to matching executions, preserving the original summary objects
+  const matching = candidates.executions.filter((exec) => {
+    const input = inputByArn.get(exec.executionArn);
+    return extractJobName(input) === jobName;
+  });
+
+  return {
+    executions: matching.slice(0, desiredCount),
+    nextToken: candidates.nextToken,
+  };
+}
+
+/**
+ * Checks if a specific job is currently running by inspecting RUNNING
+ * executions' input payloads.
+ */
+export async function isJobCurrentlyRunning(
+  stateMachineArn: string,
+  jobName: string
+): Promise<boolean> {
+  const result = await listExecutionsForJob(stateMachineArn, jobName, {
+    statusFilter: "RUNNING",
+    maxResults: 1,
+  });
+  return result.executions.length > 0;
+}
+
+/**
+ * Describes multiple executions in parallel and returns their details.
+ * Used internally to get the `input` field for filtering.
+ */
+async function describeExecutionsBatch(
+  executionArns: string[]
+): Promise<ExecutionDetail[]> {
+  if (executionArns.length === 0) return [];
+
+  const results = await Promise.allSettled(
+    executionArns.map((arn) => describeExecution(arn))
+  );
+
+  return results
+    .filter(
+      (r): r is PromiseFulfilledResult<ExecutionDetail> =>
+        r.status === "fulfilled"
+    )
+    .map((r) => r.value);
+}
+
+/**
+ * Describes a batch of executions and groups them by job name.
+ * Returns a map of jobName -> ExecutionSummary[].
+ * Executions with unrecognizable input are omitted.
+ */
+export async function groupExecutionsByJob(
+  executions: ExecutionSummary[]
+): Promise<Map<string, ExecutionSummary[]>> {
+  const described = await describeExecutionsBatch(
+    executions.map((e) => e.executionArn)
+  );
+
+  const inputByArn = new Map<string, string | undefined>();
+  for (const detail of described) {
+    inputByArn.set(detail.executionArn, detail.input);
+  }
+
+  const grouped = new Map<string, ExecutionSummary[]>();
+  for (const exec of executions) {
+    const input = inputByArn.get(exec.executionArn);
+    const name = extractJobName(input);
+    if (!name) continue;
+
+    const list = grouped.get(name);
+    if (list) {
+      list.push(exec);
+    } else {
+      grouped.set(name, [exec]);
+    }
+  }
+
+  return grouped;
+}


### PR DESCRIPTION
## Summary
- Adds `listExecutionsForJob()` and `isJobCurrentlyRunning()` to inspect execution input payloads and filter by `jobs[].job_name`
- Job detail and executions routes now show only executions for that specific job instead of all executions from the shared state machine
- Overview route describes executions once per ARN, groups by job name, then distributes to each job card

## Test plan
- [ ] Open `/transformations` — each job card should show different last run times
- [ ] Click into `daily_tables` — should show only cron executions
- [ ] Click into `manual_build` — should show only manual trigger executions (or none)
- [ ] Verify no regressions on ingestion pipeline pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)